### PR TITLE
minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ Apache-2.0
 
 ## Authors
 
-Jeremy Magland, Center for Computational Mathematics, Flatiron Institute
+Jeremy Magland and Jeff Soules, Center for Computational Mathematics, Flatiron Institute
 
 Thanks also to
-* Jeff Soules
 * Brian Ward
 * Bob Carpenter

--- a/service/src/SignalCommunicator.ts
+++ b/service/src/SignalCommunicator.ts
@@ -25,7 +25,7 @@ export class SignalCommunicatorConnection {
     #onSignalCallbacks: ((s: string) => void)[] = []
     #onCloseCallbacks: (() => void)[] = []
     #pendingSignalsToSend: string[] = []
-    #closed: boolean = false
+    #closed = false
     constructor() { }
     async handleRequest(request: WebrtcSignalingRequest): Promise<WebrtcSignalingResponse> {
         if (request.signal) {

--- a/src/WebrtcConnectionToService.ts
+++ b/src/WebrtcConnectionToService.ts
@@ -18,6 +18,7 @@ class WebrtcConnectionToService {
             }
             const response = await postApiRequest(request)
             if (response.type !== 'webrtcSignalingResponse') {
+                console.warn(response)
                 throw Error('Unexpected webrtc signaling response')
             }
             for (const sig0 of response.signals) {


### PR DESCRIPTION
My linter complained at the following line

```
#closed: boolean = false
```

saying that the type specification was not needed