### PR TITLE
Add scripting to deploy to a dev directory in gh-pages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dev-dist
 dist-ssr
 *.local
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist --no-history",
+    "dev-deploy": "tsc && vite --config vite.dev-config.ts build && gh-pages -d dist --no-history --dest dev",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist --no-history",
-    "dev-deploy": "tsc && vite --config vite.dev-config.ts build && gh-pages -d dist --no-history --dest dev",
+    "dev-deploy": "tsc && vite --config vite.dev-config.ts build && gh-pages -d dev-dist --no-history --dest dev",
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview"

--- a/vite.dev-config.ts
+++ b/vite.dev-config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [react()],
   base: "https://flatironinstitute.github.io/mcmc-monitor/dev",
+  build: {
+    outDir: "dev-dist"
+  },
   resolve: {
     alias: {
       "simple-peer": "simple-peer/simplepeer.min.js"

--- a/vite.dev-config.ts
+++ b/vite.dev-config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "https://flatironinstitute.github.io/mcmc-monitor",
+  base: "https://flatironinstitute.github.io/mcmc-monitor/dev",
   resolve: {
     alias: {
       "simple-peer": "simple-peer/simplepeer.min.js"


### PR DESCRIPTION
A few small lines to enable easy deployment to a dev directory on github-pages. No environment variable configuration needed--I just added a separate vite config script and npm command to run using it.

This works fine for deploying a dev branch without overwriting prod, but I suspect deploying a new prod would overwrite dev. That should never be a problem--in the rare case when dev still has functionality under test that isn't in prod, you can just redeploy it--but it might be worth keeping in mind.