### PR TITLE
Document dev & deployment procedures. Include LICENSE file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing Guidelines
+
+Placeholder--policy to be established

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2023 MCMC Monitor Developers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -1,0 +1,72 @@
+# MCMC Monitor Deployment
+
+As discussed in [the MCMC Monitor readme](../README.md), MCMC Monitor
+consists of a **service** and a **client**.
+
+As with many modern web applications, the MCMC client runs entirely in
+the web browser. The browser downloads prepackaged Javascript code for the client
+from a public website, and then the downloaded code handles all further
+communication with the service (which usually runs on the same machine
+that's running Stan).
+
+The MCMC Monitor developers make the client code available for download
+from the [Github Pages](https://pages.github.com/) page associated with
+this repository, https://flatironinstitute.github.io/mcmc-monitor.
+*Deploying* a new version of the client consists of packaging up the
+Javascript code and making it available for download at that URL.
+
+If you've
+[forked](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+this repo, you can deploy your own version of the MCMC Monitor client
+using the same scripts as the MCMC Monitor developers.
+This might be useful as a way to test some changes you're thinking of
+[contributing to the project](../CONTRIBUTING.md)
+(which is highly encouraged!). While it is also possible to run
+your own version of the client, we strongly recommend and humbly request
+that you share with the broader community any extensions you have made.
+
+Alternatively, it is probably easier to just run
+the client locally. See our [developer documentation](./developing.md)
+for more details on recommended workflow.
+
+
+## Deployment
+
+The project offers two deployment scripts, one for the production
+version of the client and one for a development/testing/staging branch.
+Configuration of the deployment verbs is handled in the `package.json`
+of the client `src` directory, and the build process is managed
+using [Vite](https://vitejs.dev/). As typical for github-pages-based
+deployments, the deployment commands push the fully built pacakge into
+the `gh-pages` branch of the repository's configured `origin` remote.
+
+
+### To Dev Branch
+
+Having a publicly-available `dev` or `staging` branch gives a broad
+audience of end users a convenient want to test-drive changes and see how
+their use cases would be impacted, before those changes become part
+of the main production version of the code.
+
+To do a dev deployment, execute the `dev-deploy` script as:
+```bash
+$ yarn dev-deploy
+```
+
+This will automatically build the current branch using the
+`vite.dev-config.ts` configuration and push it into a `/dev` directory
+on the repository, so it will be available at
+`https://flatironinstitute.github.io/mcmc-monitor/dev`.
+
+
+### To Production
+
+To deploy to the production branch, execute:
+```bash
+$ yarn deploy
+```
+
+This will automatically execute the `build` script as well, using the
+(default) `vite.config.ts` configuration. Additionally, the `build` script
+can be executed by itself using `yarn build` to confirm that everything has
+built correctly before attempting to deploy.

--- a/doc/developing.md
+++ b/doc/developing.md
@@ -1,0 +1,120 @@
+# How to Develop on MCMC Monitor
+
+As an open source project, particularly one in a field
+with considerable prior art and interacting with a
+broad community of users with diverse existing needs
+and use cases, MCMC Monitor welcomes contributions.
+Our [contributions policy](../CONTRIBUTING.md)
+describes the mechanics and standards of contributing,
+while this document offers practical advice on how to
+develop MCMC Monitor.
+
+## Code organization and components
+
+This repository contains both parts of MCMC Monitor: the client,
+which runs in the web browser and provides the UI and visualizations,
+and the service, which parses the CSV data files from the
+MCMC runs and serves it to the client(s).
+
+Basic project structure is as follows:
+
+- `src/` -- client code
+  - `src/components/` -- front-end code
+  - `src/MCMCMonitorDataManager/` -- code for managing interactions with service & the client-side data cache
+  - `src/pages/` -- top-level UI layouts
+- `service/` -- everything related to the service package
+  - `service/src/` -- main service code directory. Directly contains communication/protocol code and file parsing code
+    - `service/src/types/` -- all shared types for the application--including those shared by the client--should reside here
+
+This outline is an overview and does not list caches, config files, or administrative files.
+
+If you are developing on the client side, you'll mainly be
+interested in the `src` directory; if you're working on the service,
+the contents of interest are in the `service/` directory.
+
+
+## Running changes locally
+
+Access to MCMC Monitor is through a URL of the form:
+
+`https://CLIENT_LOCATION?s=SERVICE_LOCATION`
+
+When you launch the service, a URL of this form is shown on the screen, for instance:
+
+`https://flatironinstitute.github.io/mcmc-monitor?s=https://mcmc-monitor-proxy.herokuapp.com/s/5e088817c361db5a2a98&webrtc=1`
+
+In this case, the `flatironinstitute.github.io/mcmc-monitor` section refers to the
+current production version of the client (as hosted on GitHub Pages) and the part after
+the `?s=` query string (`https://mcmc-monitor-proxy.herokuapp.com/s/5e088817c361db5a2a98&webrtc=1`)
+tells the client where to find a running service instance. (The `&webrtc=1` in the query string
+also tells the client that it can use the [Web Realtime Communication](https://webrtc.org/) protocol
+to connect to the service.)
+
+During development, you will run one or both of these services locally. To access
+your local version, you will need to replace one or both of the parts of this URL with your
+local server's location. If you are working on the client, you'll use
+replace the first part; if you're working on the service, you'll replace the second part;
+and if you're working on both, you'll need to replace both.
+
+### Setup
+
+Before running, you'll need to obtain the code and install dependencies.
+
+- Clone the repository
+  - e.g. `git clone git@github.com:flatironinstitute/mcmc-monitor.git`
+  - These instructions assume you've cloned the repo into `~/src/mcmc-monitor`
+- Install client dependencies
+  - `cd ~/src/mcmc-monitor` (or wherever you cloned the repo)
+  - `yarn install` to install client dependencies
+- Install service dependencies
+  - `cd ~/src/mcmc-monitor/service`
+  - `yarn install` to install dev dependencies
+- Generate sample data
+  - `cd ~/src/mcmc-monitor/examples`
+  - If it is not yet installed, you will need to install [pystan](https://pystan.readthedocs.io/en/latest/)
+  - Run one of the `test_*.py` scripts, which will generate sample data
+  - Ensure the sample data is located in `~/src/mcmc-monitor/examples/example-output/` (This is the directory
+  that's hard-coded in the delivered script that runs the service in dev mode. If you use a different directory,
+  you'll need to edit `~/src/mcmc-monitor/service/package.json`.)
+
+### Client
+
+The project is set up to deliver the client-side code through [vite](https://vitejs.dev/).
+To run the vite server locally, ensure you are in the top level of the cloned repository
+(`~/src/mcmc-monitor`) and execute `yarn dev`. (This invokes the `dev` command defined in the
+`~/src/mcmc-monitor/package.json` file.)
+
+Leave this window open and note the "Local" url displayed (most likely `http://localhost:5173/mcmc-monitor`).
+To use your local version of the client, use this address in place of the
+`https://flatironinstitute.github.io/mcmc-monitor` part of an existing URL.
+
+### Service
+
+The service can also be run locally:
+
+- `cd ~/src/mcmc-monitor/service` (Note that this is the `service` directory)
+- `yarn dev` to invoke the script from `~/src/mcmc-monitor/service/package.json`
+  - This script is set up to use [nodemon](https://www.npmjs.com/package/nodemon), 
+  a simple live-update wrapper for Node applications, so it should automatically reload
+  and recompile when you save new changes.
+
+Caveats:
+- The configured `yarn dev` script will look for CSV files to parse in the
+  `~/src/mcmc-monitor/examples/example-output` directory, so you should ensure any data
+  you want to test on is written there.
+- Just like in production mode, the dev mode service will display a URL to access it.
+However, the service is not aware of whether you are running the client locally, so it
+will always print URLs referring to the published client version
+(`https://flatironinstitute.github.io/mcmc-monitor...`). This is fine if you are only
+developing on the service, but if you have made client-side changes as well, you will
+need to manually edit the URL to refer to the client version being served locally
+(resulting in something like `http://localhost:5713/mcmc-monitor?s=http://localhost:61542`).
+
+## Recommended Tooling
+
+Running both client and service require [nodejs](https://nodejs.org/en/) version 16+. Other
+dependencies will be pulled in automatically by the [yarn package manager](https://yarnpkg.com/).
+
+Scripts to generate example data require [python](https://www.python.org/) (version at least 3.8+).
+
+Current developers prefer to use [VSCode](https://code.visualstudio.com/) as an IDE.

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,0 +1,26 @@
+# MCMC Monitor--Releasing a New Version
+
+This documentation is intended for (and of interest mainly to) MCMC Monitor
+developers with the ability to push production versions of MCMC Monitor.
+
+To push a new release, follow these steps:
+
+1. Ensure that the `protocolVersion` string has been updated if there
+were any changes to the communication structure, protocol, or types.
+
+2. Update the `service` version in `service/package.json` if any changes
+have been made to the service.
+
+3. Commit and push changes
+
+4. Execute `yarn deploy` for the client, as per the
+[deployment instructions](./deployment.md).
+
+5. If any changes were made to the service, cd to the `service` directory,
+then update the version of the service on NPM:
+    - `$ npm login`
+    - `$ export TAG=A.B.C # where A.B.C should match the version in package.json`
+    - `$ yarn build && npm publish && git tag $TAG && git push --tags`
+
+The last command builds and publishes the service and tags the deployed version
+of the code in one serial set of operations.


### PR DESCRIPTION
Fix #3.

- LICENSE file is the recommended reference file from the Apache 2.0 license (which was already specified in the readme).
- CONTRIBUTING.md is a good idea but we need to figure out what to say in it still. (I entered a separate ticket for that)
- Documentation for deploying and developing on MCMC Monitor is intended to address the open issue.
- Documentation for releasing a new version is mainly intended for an internal audience; I think the only real issue is that others won't be interested in it, so it doesn't hurt to have it available.