### PR TITLE
Fix: Data flashing on update, by implementing explicit freshness flag for stats.

### DIFF
--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -13,6 +13,7 @@ export type SequenceStats = {
     count?: number
     ess?: number
     acor?: number[]
+    isUpToDate?: boolean
 }
 
 export type VariableStats = {
@@ -21,7 +22,11 @@ export type VariableStats = {
     ess?: number
     count?: number
     rhat?: number
+    isUpToDate?: boolean
 }
+
+type SequenceStatsDict = { [key: string]: SequenceStats }
+type VariableStatsDict = { [key: string]: VariableStats }
 
 export type MCMCMonitorData = {
     connectedToService: boolean | undefined
@@ -30,8 +35,8 @@ export type MCMCMonitorData = {
     runs: MCMCRun[]
     chains: MCMCChain[]
     sequences: MCMCSequence[]
-    sequenceStats: {[key: string]: SequenceStats}
-    variableStats: {[key: string]: VariableStats}
+    sequenceStats: SequenceStatsDict
+    variableStats: VariableStatsDict
     selectedRunId?: string
     selectedVariableNames: string[]
     selectedChainIds: string[]
@@ -179,18 +184,12 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         }
     }
     else if (a.type === 'appendSequenceData') {
-        const k = `${a.runId}/${a.chainId}/${a.variableName}`
-        const k2 = `${a.runId}/${a.variableName}`
+        const sequenceStatsIndex = `${a.runId}/${a.chainId}/${a.variableName}`
+        const variableStatsIndex = `${a.runId}/${a.variableName}`
         return {
             ...s,
-            sequenceStats: {
-                ...s.sequenceStats,
-                [k]: {} // invalidate the sequence stats
-            },
-            variableStats: {
-                ...s.variableStats,
-                [k2]: {} //invalidate the variable stats
-            },
+            sequenceStats: invalidateStats(s.sequenceStats, sequenceStatsIndex),
+            variableStats: invalidateStats(s.variableStats, variableStatsIndex),
             sequences: s.sequences.map(x => (
                 (x.runId !== a.runId || x.chainId !== a.chainId || x.variableName !== a.variableName) ?
                     x : {...x, data: appendData(x.data, a.position, a.data)}
@@ -253,8 +252,8 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         const recalc = effectiveWarmupIterations !== s.effectiveInitialDrawsToExclude
         return {
             ...s,
-            sequenceStats: recalc ? {} : s.sequenceStats, // invalidate the sequence stats
-            variableStats: recalc ? {} : s.variableStats, // invalidate the variable stats
+            sequenceStats: recalc ? invalidateStats(s.sequenceStats) : s.sequenceStats,
+            variableStats: recalc ? invalidateStats(s.variableStats) : s.variableStats,
             effectiveInitialDrawsToExclude: effectiveWarmupIterations,
             generalOpts: a.opts
         }
@@ -334,4 +333,18 @@ const computeEffectiveWarmupIterations = (data: MCMCMonitorData, requested: numb
     } else {
         return requested
     }
+}
+
+
+const invalidateStats = <T extends SequenceStatsDict | VariableStatsDict>(statsDict: T, key?: string): T => {
+    if (key === undefined) {
+        Object.keys(statsDict).forEach(s => statsDict[s].isUpToDate = false)
+    }
+    else if (key in Object.keys(statsDict)) {
+        statsDict[key].isUpToDate = false
+    } else {
+        console.warn(`Attempt to invalidate stats with key ${key}, which is not in the dictionary.`)
+    }
+
+    return statsDict
 }

--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -184,12 +184,12 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         }
     }
     else if (a.type === 'appendSequenceData') {
-        const sequenceStatsIndex = `${a.runId}/${a.chainId}/${a.variableName}`
-        const variableStatsIndex = `${a.runId}/${a.variableName}`
+        const sequenceStatsKey = `${a.runId}/${a.chainId}/${a.variableName}`
+        const variableStatsKey = `${a.runId}/${a.variableName}`
         return {
             ...s,
-            sequenceStats: invalidateStats(s.sequenceStats, sequenceStatsIndex),
-            variableStats: invalidateStats(s.variableStats, variableStatsIndex),
+            sequenceStats: invalidateStats(s.sequenceStats, sequenceStatsKey),
+            variableStats: invalidateStats(s.variableStats, variableStatsKey),
             sequences: s.sequences.map(x => (
                 (x.runId !== a.runId || x.chainId !== a.chainId || x.variableName !== a.variableName) ?
                     x : {...x, data: appendData(x.data, a.position, a.data)}
@@ -206,8 +206,6 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         }
     }
     else if (a.type === 'updateSequence') {
-        // const k = `${a.runId}/${a.chainId}/${a.variableName}`
-        // const k2 = `${a.runId}/${a.variableName}`
         if (!s.sequences.find(x => (x.runId === a.runId && x.chainId === a.chainId && x.variableName === a.variableName))) {
             return {
                 ...s,
@@ -223,14 +221,6 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         else {
             return {
                 ...s,
-                // sequenceStats: {
-                //     ...s.sequenceStats,
-                //     [k]: {} // invalidate
-                // },
-                // variableStats: {
-                //     ...s.variableStats,
-                //     [k2]: {} // invalidate
-                // },
                 sequences: s.sequences.map(x => (
                     (x.runId !== a.runId || x.chainId !== a.chainId || x.variableName !== a.variableName) ?
                         x : {...x, updateRequested: true}

--- a/src/MCMCMonitorDataManager/updateVariableStats.ts
+++ b/src/MCMCMonitorDataManager/updateVariableStats.ts
@@ -8,7 +8,7 @@ export default async function updateVariableStats(data: MCMCMonitorData, dispatc
     for (const variableName of data.selectedVariableNames) {
         const k = `${runId}/${variableName}`
         const s = data.variableStats[k] || {}
-        if (s.mean === undefined) {
+        if (!s.isUpToDate) {
             const chainStats: SequenceStats[] = data.selectedChainIds.map(chainId => {
                 const k2 = `${runId}/${chainId}/${variableName}`
                 return data.sequenceStats[k2] || {}
@@ -24,7 +24,8 @@ export default async function updateVariableStats(data: MCMCMonitorData, dispatc
                     stdev,
                     ess,
                     count,
-                    rhat
+                    rhat,
+                    isUpToDate: true
                 }
                 dispatch({
                     type: 'setVariableStats',


### PR DESCRIPTION
Resolves issue #8.

Principal changes:

- `MCMCMonitorData.ts` (the main client-side data cache manager):
  - Add `isUpToDate` optional member to the SequenceStats and VariableStats types.
  - Formally define dictionary of these keyed sets of statistics in the `MCMCMonitorData` client-side data cache.
  - Add function (applicable to both) which invalidates either one key or the whole dictionary, without deleting its existing data.
- `updateSequenceStats.ts` -- sequence-stats updater called at each update check
  - Test for up-to-date-ness now based on the flag, rather than checking whether the mean is defined
  - Do not mark empty sequences as up-to-date
- `updateVariableStats.ts` -- variable-stats updater called at each update check
  - Test for up-to-date-ness now based on the flag, rather than checking whether mean is defined
  - This doesn't need to be as fussy about marking empty data as up-to-date--if that does happen, the underlying sequence data will refresh shortly, which will invalidate the overall variable data as well

Acceptance testing:

- Ensured the existing issue was reproducible on `main` branch with default example (e.g. by changing the set of selected variables or the number of warmup iterations)
- Implemented changes and reran test. Confirmed that values are initially populated as expected, and that they no longer flicker to an unpopulated state between updates. Confirmed that values do still update when changes are made.