### PR TITLE
Fix: Implement sort when storing multi-select values to cache.

### DIFF
--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -145,13 +145,13 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
     else if (a.type === 'setSelectedVariableNames') {
         return {
             ...s,
-            selectedVariableNames: a.variableNames.sort()
+            selectedVariableNames: [...a.variableNames].sort()
         }
     }
     else if (a.type === 'setSelectedChainIds') {
         return {
             ...s,
-            selectedChainIds: a.chainIds.sort()
+            selectedChainIds: [...a.chainIds].sort()
         }
     }
     else if (a.type === 'setSelectedRunId') {

--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -145,13 +145,13 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
     else if (a.type === 'setSelectedVariableNames') {
         return {
             ...s,
-            selectedVariableNames: a.variableNames
+            selectedVariableNames: a.variableNames.sort()
         }
     }
     else if (a.type === 'setSelectedChainIds') {
         return {
             ...s,
-            selectedChainIds: a.chainIds
+            selectedChainIds: a.chainIds.sort()
         }
     }
     else if (a.type === 'setSelectedRunId') {


### PR DESCRIPTION
Fixes #16.

Acceptance test:

- View example data with PR code and current prod.
- Chain selection:
  - In Prod "Diagnostics" tab, confirm that deselecting and reselecting chain 1 will cause chain 1 to be displayed on top of the other chains in the graph, i.e. drawn last.
  - In this code, confirm that deselceting and reselecting chain 1 results in the same image (z-ordering) as on initial load.
- Load "Tables" tab in both versions.
  - Confirm that in prod, adding the `accept_stat__` variable to the initially selected `lp__` puts that `accept_stat__` at the bottom. Deselecting and reselecting `lp__` results in `accept_stat__` bubbling up to the top of the order, with `lp__` now last. Confirm this behavior matches the ordering of the variables display on the Diagnostics tab.
  - In this code, confirm that the same test results in a consistent alphabetical ordering for all selected variables.

Question: Do we want to sort so that `lp__`, if present, is always at the top?