### PR TITLE
Adds client-side awareness of service protocol. Displays on mismatch.

### DIFF
--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -30,6 +30,7 @@ type VariableStatsDict = { [key: string]: VariableStats }
 
 export type MCMCMonitorData = {
     connectedToService: boolean | undefined
+    serviceProtocolVersion: string | undefined
     webrtcConnectionStatus: 'unused' | 'pending' | 'connected' | 'error'
     usingProxy: boolean | undefined
     runs: MCMCRun[]
@@ -46,6 +47,7 @@ export type MCMCMonitorData = {
 
 export const initialMCMCMonitorData: MCMCMonitorData = {
     connectedToService: undefined,
+    serviceProtocolVersion: undefined,
     webrtcConnectionStatus: 'pending',
     usingProxy: undefined,
     runs: [],
@@ -100,6 +102,9 @@ export type MCMCMonitorAction = {
 } | {
     type: 'setConnectedToService'
     connected: boolean | undefined
+} | {
+    type: 'setServiceProtocolVersion'
+    version: string | undefined
 } | {
     type: 'setWebrtcConnectionStatus'
     status: 'unused' | 'pending' | 'connected' | 'error'
@@ -169,6 +174,12 @@ export const mcmcMonitorReducer = (s: MCMCMonitorData, a: MCMCMonitorAction): MC
         return {
             ...s,
             connectedToService: a.connected
+        }
+    }
+    else if (a.type === 'setServiceProtocolVersion') {
+        return {
+            ...s,
+            serviceProtocolVersion: a.version
         }
     }
     else if (a.type === 'setWebrtcConnectionStatus') {

--- a/src/MainWindow.tsx
+++ b/src/MainWindow.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent, useEffect } from "react";
+import { protocolVersion } from "../service/src/types/MCMCMonitorRequest";
 import Logo from "./Logo";
 import Hyperlink from "./components/Hyperlink";
 import { defaultServiceBaseUrl, exampleServiceBaseUrl, serviceBaseUrl, useWebrtc } from "./config";
@@ -7,11 +8,12 @@ import RunPage from "./pages/RunPage";
 import { useMCMCMonitor } from "./useMCMCMonitor";
 import useRoute from "./useRoute";
 
+
 type Props = any
 
 const MainWindow: FunctionComponent<Props> = () => {
 	const { route } = useRoute()
-	const { updateRuns } = useMCMCMonitor()
+	const { updateRuns, serviceProtocolVersion } = useMCMCMonitor()
 
 	useEffect(() => {
 		updateRuns()
@@ -37,6 +39,7 @@ const MainWindow: FunctionComponent<Props> = () => {
 				<Logo />
 				<hr />
 				<div style={{color: 'darkred'}}>Not connected to service {serviceBaseUrl}</div>
+                <ProtocolCheck expectedProtocol={protocolVersion} serviceProtocol={serviceProtocolVersion} />
 				<hr />
 				<div>
 					{
@@ -67,6 +70,24 @@ const MainWindow: FunctionComponent<Props> = () => {
 			}
 		</div>
 	)
+}
+
+type ProtocolCheckProps = {
+    expectedProtocol: string
+    serviceProtocol?: string
+}
+
+const ProtocolCheck: FunctionComponent<ProtocolCheckProps> = (props: ProtocolCheckProps) => {
+    const { expectedProtocol, serviceProtocol } = props
+    if (serviceProtocol === undefined || expectedProtocol === serviceProtocol) {
+        return <></>
+    }
+    return <div>
+        <hr />
+        <div><b>PROTOCOL MISMATCH:</b> Connected service is running protocol version {serviceProtocol} while we expect {expectedProtocol}.
+        Please contact the service administrator and request that they upgrade.
+        </div>
+    </div>
 }
 
 export default MainWindow

--- a/src/MainWindow.tsx
+++ b/src/MainWindow.tsx
@@ -84,7 +84,7 @@ const ProtocolCheck: FunctionComponent<ProtocolCheckProps> = (props: ProtocolChe
     }
     return <div>
         <hr />
-        <div><b>PROTOCOL MISMATCH:</b> Connected service is running protocol version {serviceProtocol} while we expect {expectedProtocol}.
+        <div><span style={{fontWeight: "bolder"}}>PROTOCOL MISMATCH:</span> Connected service is running protocol version {serviceProtocol} while we expect {expectedProtocol}.
         Please contact the service administrator and request that they upgrade.
         </div>
     </div>

--- a/src/SetupMCMCMonitor.tsx
+++ b/src/SetupMCMCMonitor.tsx
@@ -87,6 +87,7 @@ const SetupMCMCMonitor: FunctionComponent<PropsWithChildren> = ({children}) => {
                         throw Error('Unexpected probe response')
                     }
                     setUsingProxy(resp.proxy ? true : false)
+                    dataDispatch({type: 'setServiceProtocolVersion', version: resp.protocolVersion})
                     if (resp.protocolVersion !== protocolVersion) {
                         throw Error(`Unexpected protocol version: ${resp.protocolVersion} <> ${protocolVersion}`)
                     }

--- a/src/useMCMCMonitor.ts
+++ b/src/useMCMCMonitor.ts
@@ -90,6 +90,7 @@ export const useMCMCMonitor = () => {
         selectedChainIds: data.selectedChainIds,
         selectedRunId: data.selectedRunId,
         connectedToService: data.connectedToService,
+        serviceProtocolVersion: data.serviceProtocolVersion,
         webrtcConnectionStatus: data.webrtcConnectionStatus,
         usingProxy: data.usingProxy,
         generalOpts: data.generalOpts,


### PR DESCRIPTION
Fix #25.

This PR adds a `serviceProtocolVersion` key as part of the client-side backing cache (`MCMCMonitorData` object), which (if defined) stores the protocol version received from the connected service. The data is set during `SetupMCMCMonitor` and returned as part of the cache-invocation hook `useMCMCMonitor`.

The service protocol version is consumed in `MainWindow.tsx`, which now also imports the current-build protocol version. In the event of a failed connection to service, `MainWindow.tsx` feeds the current-build expected protocol version and the version received from the service into an internal component; if the service protocol version is set and differs from the expected version, the internal component displays a message informing the user to upgrade the service version.

**Note:**
This is just a simple-minded equality check. We are not currently making any effort at checking semantic protocol versions.

### Acceptance test:
- Run this code as client locally
- Run an intentionally out-of-date service version (e.g. `npx mcmc-monitor@0.1.10 ...`) and connect to it
- Confirm that error message is displayed
- Terminate out-of-date service and start up-to-date service (or just click on the example data link)
- Confirm that no error message is displayed and the website functions as expected