### PR TITLE
add all chains hist in diag tab (issue 22)

### DIFF
--- a/src/components/DiagnosticsTab.tsx
+++ b/src/components/DiagnosticsTab.tsx
@@ -96,11 +96,13 @@ const Diagnostics: FunctionComponent<Props> = ({runId, numDrawsForRun, chainColo
 										/>}
 									</Grid>
 									{
+										// histograms for individual chains
 										diagnosticsSelection.histogram && selectedChainIds.map(chainId => (
 											<Grid item key={chainId}>
 												<SequenceHistogram
 													runId={runId}
 													chainId={chainId}
+													title={chainId}
 													variableName={v}
 													drawRange={sequenceHistogramDrawRange}
 													width={Math.min(width, 300 * sizeScale)}
@@ -108,6 +110,22 @@ const Diagnostics: FunctionComponent<Props> = ({runId, numDrawsForRun, chainColo
 												/>
 											</Grid>
 										))
+									}
+									{
+										// histogram for all chains
+										diagnosticsSelection.histogram && (
+											<Grid item key={"___all_chains"}>
+												<SequenceHistogram
+													runId={runId}
+													chainId={selectedChainIds}
+													title="All selected chains"
+													variableName={v}
+													drawRange={sequenceHistogramDrawRange}
+													width={Math.min(width, 300 * sizeScale)}
+													height={450 * sizeScale}
+												/>
+											</Grid>
+										)
 									}
 									{
 										diagnosticsSelection.acf && selectedChainIds.map(chainId => (

--- a/src/components/ScatterplotsTab.tsx
+++ b/src/components/ScatterplotsTab.tsx
@@ -152,6 +152,7 @@ const ScatterplotsTab: FunctionComponent<Props> = ({ runId, numDrawsForRun, chai
 														key={ii}
 														runId={runId}
 														chainId={selectedChainIds}
+														title=""
 														variableName={v1}
 														drawRange={sequenceHistogramDrawRange}
 														width={0}

--- a/src/components/SequenceHistogram.tsx
+++ b/src/components/SequenceHistogram.tsx
@@ -7,11 +7,12 @@ type Props = {
 	chainId: string | string[]
 	variableName: string
 	drawRange: [number, number] | undefined
+	title: string
 	width: number
 	height: number
 }
 
-const SequenceHistogram: FunctionComponent<Props> = ({runId, chainId, variableName, drawRange, width, height}) => {
+const SequenceHistogram: FunctionComponent<Props> = ({runId, chainId, variableName, drawRange, title, width, height}) => {
 	const {sequences} = useMCMCMonitor()
 	const histData = useMemo(() => {
 		function getDataForChain(ch: string) {
@@ -31,7 +32,7 @@ const SequenceHistogram: FunctionComponent<Props> = ({runId, chainId, variableNa
 		}
 	}, [chainId, sequences, runId, variableName, drawRange])
 	return (
-		<SequenceHistogramWidget histData={histData} variableName={variableName} title={!Array.isArray(chainId) ? chainId : ''} width={width} height={height} />
+		<SequenceHistogramWidget histData={histData} variableName={variableName} title={title} width={width} height={height} />
 	)
 }
 


### PR DESCRIPTION
#22

Adds a new histogram for each variable in the diagnostics tab titled "All selected chains"

![image](https://user-images.githubusercontent.com/3679296/224063338-6b4e9ea9-fe6f-4735-aed5-002ca9293eef.png)

As part of this I made "title" an explicit prop in SequenceHistogram component - so that based on context we can choose the title appropriately (this component is also included in the scatterplots tab)

Testing:
I tested this on my local machine, with the example data