### PR TITLE
Add repo link. Slight reorg of MainWindow code.

### DIFF
--- a/src/MainWindow.tsx
+++ b/src/MainWindow.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect } from "react";
+import { Fragment, FunctionComponent, PropsWithChildren, useEffect } from "react";
 import { protocolVersion } from "../service/src/types/MCMCMonitorRequest";
 import Logo from "./Logo";
 import Hyperlink from "./components/Hyperlink";
@@ -22,54 +22,100 @@ const MainWindow: FunctionComponent<Props> = () => {
 	const {connectedToService, webrtcConnectionStatus} = useMCMCMonitor()
 
 	if (webrtcConnectionStatus === 'error') {
-		return (
-			<div>Unable to connect to service using WebRTC: {serviceBaseUrl}</div>
-		)
+        return <WebRtcError />
 	}
 
 	if (connectedToService === undefined) {
-		return (
-			<div>Connecting to service{useWebrtc ? ' using WebRTC' : ''}: {serviceBaseUrl}</div>
-		)
+        return <ConnectionInProgress />
 	}
 
 	if (connectedToService === false) {
 		return (
-			<div style={{margin: 60}}>
-				<Logo />
-				<hr />
-				<div style={{color: 'darkred'}}>Not connected to service {serviceBaseUrl}</div>
-                <ProtocolCheck expectedProtocol={protocolVersion} serviceProtocol={serviceProtocolVersion} />
-				<hr />
-				<div>
-					{
-						serviceBaseUrl !== exampleServiceBaseUrl && (
-							<Hyperlink
-								onClick={() => {;(window as any).location = `${window.location.protocol}//${window.location.host}${window.location.pathname}?s=${exampleServiceBaseUrl}`}}
-							>View example data</Hyperlink>
-						)
-					}
-				</div>
-				{
-					serviceBaseUrl === defaultServiceBaseUrl && (
-						<p><a href="https://github.com/flatironinstitute/mcmc-monitor" target="_blank" rel="noreferrer">How to run a local service</a></p>
-					)
-				}
-			</div>
+            <LogoFrame>
+                <FailedConnection serviceProtocolVersion={serviceProtocolVersion} />
+            </LogoFrame>
 		)
 	}
 
-	return (
-		<div>
-			{
-				route.page === 'home' ? (
-					<Home />
-				) : route.page === 'run' ? (
-					<RunPage runId={route.runId} />
-				) : <span />
-			}
-		</div>
-	)
+    switch (route.page) {
+        case "home":
+            return (
+                <LogoFrame>
+                    <Home />
+                </LogoFrame>
+            )
+            break
+        case "run":
+            return <RunPage runId={route.runId} />
+            break
+        default:
+            return <span />
+    }
+}
+
+const WebRtcError: FunctionComponent = () => {
+    return (
+        <div>Unable to connect to service using WebRTC: {serviceBaseUrl}</div>
+    )
+}
+
+const ConnectionInProgress: FunctionComponent = () => {
+    return (
+        <div>Connecting to service{useWebrtc ? ' using WebRTC' : ''}: {serviceBaseUrl}</div>
+    )
+}
+
+const LogoFrame: FunctionComponent<PropsWithChildren> = ({children}) => {
+    return (
+        <div style={{margin: 60}}>
+            <Logo />
+            <h3>WIP</h3>
+            {children}
+            <hr />
+            <GithubLink />
+        </div>
+    )
+}
+
+type FailedConnectionProps = {
+    serviceProtocolVersion: string | undefined
+}
+
+const FailedConnection: FunctionComponent<FailedConnectionProps> = (props: FailedConnectionProps) => {
+    const { serviceProtocolVersion } = props
+    return (
+        <Fragment>
+            <div style={{color: 'darkred'}}>Not connected to service {serviceBaseUrl}</div>
+            <ProtocolCheck expectedProtocol={protocolVersion} serviceProtocol={serviceProtocolVersion} />
+            <hr />
+            <div>
+                {
+                    serviceBaseUrl !== exampleServiceBaseUrl && (
+                        <Hyperlink
+                            onClick={() => {;(window as any).location = `${window.location.protocol}//${window.location.host}${window.location.pathname}?s=${exampleServiceBaseUrl}`}}
+                        >View example data</Hyperlink>
+                    )
+                }
+            </div>
+            {
+                serviceBaseUrl === defaultServiceBaseUrl && (
+                    <p><a href="https://github.com/flatironinstitute/mcmc-monitor" target="_blank" rel="noreferrer">How to run a local service</a></p>
+                )
+            }
+        </Fragment>
+    )
+}
+
+const GithubLink: FunctionComponent = () => {
+    return <Fragment>
+        <div style={{margin: 25}}>
+            <span>
+                To report issues, make suggestions, or check for updates, please visit <Hyperlink
+                    onClick={() => {;(window as any).location = "https://github.com/flatironinstitute/mcmc-monitor"}}
+                >the project Github repository</Hyperlink>.
+            </span>
+        </div>
+    </Fragment>
 }
 
 type ProtocolCheckProps = {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,4 @@
-import { FunctionComponent } from "react";
-import Logo from "../Logo";
+import { Fragment, FunctionComponent } from "react";
 import ConnectionStatusWidget from "../components/ConnectionStatusWidget";
 import Hyperlink from "../components/Hyperlink";
 import RunsTable from "../components/RunsTable";
@@ -9,9 +8,7 @@ type Props = any
 
 const Home: FunctionComponent<Props> = () => {
 	return (
-		<div style={{margin: 60}}>
-			<Logo />
-			<h3>WIP</h3>
+        <Fragment>
 			{
 				serviceBaseUrl !== exampleServiceBaseUrl && (
 					<div>
@@ -34,7 +31,7 @@ const Home: FunctionComponent<Props> = () => {
 			<RunsTable />
 			<hr />
 			<ConnectionStatusWidget />
-		</div>
+        </Fragment>
 	)
 }
 


### PR DESCRIPTION
Fix #33.

This mainly just adds the footer with the Github link to the "error connection" and "home" pages, but I also did a little light reorganization of the `MainWindow.tsx` to reduce some redundancy and break its components out a little bit more.