### PR TITLE
Separate cache initialization from polling start/stop.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
+import { useState } from 'react'
 import { HashRouter } from 'react-router-dom'
 import './App.css'
+import MCMCDataManager from './MCMCMonitorDataManager/MCMCMonitorDataManager'
 import MainWindow from './MainWindow'
 import SetupMCMCMonitor from './SetupMCMCMonitor'
 
 function App() {
+    const [dataManager, setDataManager] = useState<MCMCDataManager | undefined>()
   return (
     <HashRouter>
-      <SetupMCMCMonitor>
-        <MainWindow />
+      <SetupMCMCMonitor dataManager={dataManager} setDataManager={setDataManager}>
+        <MainWindow dataManager={dataManager} />
       </SetupMCMCMonitor>
     </HashRouter>
   )

--- a/src/MCMCMonitorDataManager/MCMCMonitorData.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorData.ts
@@ -344,7 +344,8 @@ const invalidateStats = <T extends SequenceStatsDict | VariableStatsDict>(statsD
     else if (key in Object.keys(statsDict)) {
         statsDict[key].isUpToDate = false
     } else {
-        console.warn(`Attempt to invalidate stats with key ${key}, which is not in the dictionary.`)
+        // No-op--this situation is actually entirely expected.
+        // console.warn(`Attempt to invalidate stats with key ${key}, which is not in the dictionary.`)
     }
 
     return statsDict

--- a/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
@@ -13,6 +13,7 @@ class MCMCDataManager {
     }
     async start() {
         // eslint-disable-next-line no-constant-condition
+        this.#stopped = false
         while (true) {
             if (this.#stopped) return
             await this._iterate()

--- a/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
@@ -12,8 +12,8 @@ class MCMCDataManager {
         this.#data = data
     }
     async start() {
-        // eslint-disable-next-line no-constant-condition
         this.#stopped = false
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             if (this.#stopped) return
             await this._iterate()

--- a/src/MainWindow.tsx
+++ b/src/MainWindow.tsx
@@ -1,6 +1,7 @@
 import { Fragment, FunctionComponent, PropsWithChildren, useEffect } from "react";
 import { protocolVersion } from "../service/src/types/MCMCMonitorRequest";
 import Logo from "./Logo";
+import MCMCDataManager from "./MCMCMonitorDataManager/MCMCMonitorDataManager";
 import Hyperlink from "./components/Hyperlink";
 import { defaultServiceBaseUrl, exampleServiceBaseUrl, serviceBaseUrl, useWebrtc } from "./config";
 import Home from "./pages/Home";
@@ -9,12 +10,14 @@ import { useMCMCMonitor } from "./useMCMCMonitor";
 import useRoute from "./useRoute";
 
 
-type Props = any
+type Props = {
+    dataManager: MCMCDataManager | undefined
+}
 
-const MainWindow: FunctionComponent<Props> = () => {
+const MainWindow: FunctionComponent<Props> = (props: Props) => {
+    const { dataManager } = props
 	const { route } = useRoute()
 	const { updateRuns, serviceProtocolVersion } = useMCMCMonitor()
-
 	useEffect(() => {
 		updateRuns()
 	}, [updateRuns])
@@ -46,7 +49,7 @@ const MainWindow: FunctionComponent<Props> = () => {
             )
             break
         case "run":
-            return <RunPage runId={route.runId} />
+            return <RunPage runId={route.runId} dataManager={dataManager} />
             break
         default:
             return <span />

--- a/src/SetupMCMCMonitor.tsx
+++ b/src/SetupMCMCMonitor.tsx
@@ -1,24 +1,25 @@
-import { FunctionComponent, PropsWithChildren, useCallback, useEffect, useMemo, useReducer, useState } from "react"
+import { Dispatch, FunctionComponent, PropsWithChildren, SetStateAction, useCallback, useEffect, useMemo, useReducer, useState } from "react"
 import { ProbeRequest, isProbeResponse, protocolVersion } from "../service/src/types/MCMCMonitorRequest"
 import { MCMCMonitorContext, initialMCMCMonitorData, mcmcMonitorReducer } from "./MCMCMonitorDataManager/MCMCMonitorData"
 import MCMCDataManager from "./MCMCMonitorDataManager/MCMCMonitorDataManager"
 import { useWebrtc, webrtcConnectionToService } from "./config"
 import postApiRequest from "./postApiRequest"
 
-const SetupMCMCMonitor: FunctionComponent<PropsWithChildren> = ({children}) => {
+type SetupMcmcMonitorProps = {
+    dataManager: MCMCDataManager | undefined
+    setDataManager: Dispatch<SetStateAction<MCMCDataManager | undefined>>
+}
+
+const SetupMCMCMonitor: FunctionComponent<PropsWithChildren<SetupMcmcMonitorProps>> = (props: PropsWithChildren<SetupMcmcMonitorProps>) => {
+    const { children, dataManager, setDataManager } = props
     const [data, dataDispatch] = useReducer(mcmcMonitorReducer, initialMCMCMonitorData)
-    const [dataManager, setDataManager] = useState<MCMCDataManager | undefined>()
     const [usingProxy, setUsingProxy] = useState<boolean | undefined>(undefined)
 
     // instantiate the data manager
     useEffect(() => {
         // should only be instantiated once
         const dm = new MCMCDataManager(dataDispatch)
-        dm.start()
         setDataManager(dm)
-        return () => {
-            dm.stop()
-        }
     }, [dataDispatch])
 
 

--- a/src/pages/RunPage.tsx
+++ b/src/pages/RunPage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, useEffect, useMemo } from "react";
 import { MCMCChain, MCMCRun } from "../../service/src/types/MCMCMonitorTypes";
+import MCMCDataManager from "../MCMCMonitorDataManager/MCMCMonitorDataManager";
 import { chainColorForIndex } from "../chainColorList";
 import ConnectionTab from "../components/ConnectionTab";
 import Diagnostics from "../components/DiagnosticsTab";
@@ -15,10 +16,17 @@ import useWindowDimensions from "../useWindowDimensions";
 
 type Props = {
 	runId: string
+    dataManager: MCMCDataManager | undefined
 }
 
-const RunPage: FunctionComponent<Props> = ({runId}) => {
+const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
 	const {runs, chains, sequences, updateChainsForRun, setSelectedChainIds, generalOpts, updateKnownData, setSelectedRunId} = useMCMCMonitor()
+
+    useEffect(() => {
+        if (dataManager === undefined) return
+        dataManager.start()
+        return () => { dataManager.stop() }
+    }, [dataManager])
 
 	useEffect(() => {
 		setSelectedRunId(runId)


### PR DESCRIPTION
Fix #17.

This PR separates the step of initializing the `MCMCDataManager` cache from the control for turning its polling off and on, which is now attached to the `RunPage` page/component directly so that the polling gets terminated in the cleanup step when we're on a page where it isn't relevant.

To do this, I've moved the cache object itself into the base `App` level and have the reference passed down a couple levels. It's not the greatest, but I didn't really want to set up yet another context object; however, it's possible this would be better managed by a custom hook. I played around with that for a bit but the underlying state wasn't updating properly, so I left it be and stuck with this solution, inelegant though it may be.