### PR TITLE
Ensure refreshing chains does not overwrite selected variables.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-undef
 module.exports = {
     "env": {
         "browser": true,
@@ -22,6 +23,7 @@ module.exports = {
     ],
     "rules": {
         "@typescript-eslint/no-explicit-any": "off",
+        "no-constant-condition": ["error", { "checkLoops": false }],
         "react/react-in-jsx-scope": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-extra-semi": "off"

--- a/service/src/ChainFile.ts
+++ b/service/src/ChainFile.ts
@@ -26,7 +26,7 @@ class ChainFile {
     constructor(public path: string, public chainId: string) {
         this._reset()
     }
-    _reset(stillUpdating: boolean = false) {
+    _reset(stillUpdating = false) {
         this.#columnNames = undefined
         this.#columnIndicesToInclude = undefined
         this.#variablePrefixesExcluded = undefined
@@ -127,7 +127,7 @@ class ChainFile {
         try {
             // read the file starting from where we left off
             const txt = await readNewData(this.#filePosition, this.path)
-            if (txt.length >= 0) {
+            if (txt.length > 0) {
                 this.#filePosition += txt.length + 1
                 this.parseData(txt)
                 this.#timestampLastChange = Date.now()

--- a/service/src/ChainFile.ts
+++ b/service/src/ChainFile.ts
@@ -128,7 +128,7 @@ class ChainFile {
             // read the file starting from where we left off
             const txt = await readNewData(this.#filePosition, this.path)
             if (txt.length > 0) {
-                this.#filePosition += txt.length + 1
+                this.#filePosition += txt.length
                 this.parseData(txt)
                 this.#timestampLastChange = Date.now()
             }
@@ -261,7 +261,7 @@ const readNewData = async (lastReadByte: number, path: string): Promise<string> 
     }
     // drop any partially-read lines
     const lastNewlineLoc = txt.lastIndexOf('\n')
-    txt = lastNewlineLoc >= 0 ? txt.slice(0, lastNewlineLoc) : ''
+    txt = lastNewlineLoc >= 0 ? txt.slice(0, lastNewlineLoc + 1) : ''
     return txt
 }
 

--- a/service/src/Server.ts
+++ b/service/src/Server.ts
@@ -92,7 +92,6 @@ class Server {
 
         // clean up output manager periodically
         ;(async () => {
-            // eslint-disable-next-line no-constant-condition
             while (true) {
                 await this.#outputManager.clearOldData()
                 await sleepMsec(30 * 1000)
@@ -125,6 +124,7 @@ function sha1Hash(x: string) {
 
 // Note: If we ever have more hard dependencies, we might make this more sophisticated in passing in the package requirements list.
 const checkNodeVersion = () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const data = require(PATH_TO_PACKAGE_JSON)
     const needs = data["engines"]
     check(

--- a/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorDataManager.ts
@@ -13,7 +13,6 @@ class MCMCDataManager {
     }
     async start() {
         this.#stopped = false
-        // eslint-disable-next-line no-constant-condition
         while (true) {
             if (this.#stopped) return
             await this._iterate()

--- a/src/SetupMCMCMonitor.tsx
+++ b/src/SetupMCMCMonitor.tsx
@@ -20,7 +20,7 @@ const SetupMCMCMonitor: FunctionComponent<PropsWithChildren<SetupMcmcMonitorProp
         // should only be instantiated once
         const dm = new MCMCDataManager(dataDispatch)
         setDataManager(dm)
-    }, [dataDispatch])
+    }, [dataDispatch, setDataManager])
 
 
     // every time data changes, the dataManager needs to get the updated data

--- a/src/components/RunControlPanel.tsx
+++ b/src/components/RunControlPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useMemo } from "react";
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import { useMCMCMonitor } from "../useMCMCMonitor";
 import useRoute from "../useRoute";
 import ChainsSelector from "./ChainsSelector";
@@ -16,6 +16,7 @@ const RunControlPanel: FunctionComponent<Props> = ({numDrawsForRun, chainColors}
 	const {setRoute} = useRoute()
 	const chainsForRun = useMemo(() => (chains.filter(c => (c.runId === runId))), [chains, runId])
     const { warmupOptions, detectedInitialDrawExclusion } = initialDrawExclusionOptions
+    const [ knownVariableNames, setKnownVariableNames ] = useState<string[]>([])
 
 	const allVariableNames = useMemo(() => {
 		const s = new Set<string>()
@@ -41,12 +42,21 @@ const RunControlPanel: FunctionComponent<Props> = ({numDrawsForRun, chainColors}
 		return [...s].sort()
 	}, [chainsForRun])
 
+    useEffect(() => {
+        const known = new Set(knownVariableNames)
+        if (knownVariableNames.length !== allVariableNames.length || allVariableNames.some(n => !known.has(n))) {
+            setKnownVariableNames(allVariableNames)
+        }
+    }, [knownVariableNames, allVariableNames])
+
 	useEffect(() => {
 		// start with just lp__ selected
-        if (allVariableNames.includes('lp__')) {
+        if (knownVariableNames.includes('lp__')) {
             setSelectedVariableNames(['lp__'])
+        } else {
+            setSelectedVariableNames([])
         }
-	}, [runId, setSelectedVariableNames, allVariableNames])
+	}, [runId, setSelectedVariableNames, knownVariableNames])
 
 	return (
 		<div style={{fontSize: 14}}>
@@ -60,7 +70,7 @@ const RunControlPanel: FunctionComponent<Props> = ({numDrawsForRun, chainColors}
 			</div>
 			<h3>Variables</h3>
 			<div style={{position: 'relative', maxHeight: 200, overflowY: 'auto'}}>
-				<VariablesSelector variableNames={allVariableNames} variablePrefixesExcluded={allVariablePrefixesExcluded} />
+				<VariablesSelector variableNames={knownVariableNames} variablePrefixesExcluded={allVariablePrefixesExcluded} />
 			</div>
 			<h3>Options</h3>
 			<GeneralOptsControl warmupOptions={warmupOptions} detectedInitialDrawExclusion={detectedInitialDrawExclusion} />

--- a/src/components/RunControlPanel.tsx
+++ b/src/components/RunControlPanel.tsx
@@ -43,9 +43,9 @@ const RunControlPanel: FunctionComponent<Props> = ({numDrawsForRun, chainColors}
 
 	useEffect(() => {
 		// start with just lp__ selected
-		if (allVariableNames.includes('lp__')) {
-			setSelectedVariableNames(['lp__'])
-		}
+        if (allVariableNames.includes('lp__')) {
+            setSelectedVariableNames(['lp__'])
+        }
 	}, [runId, setSelectedVariableNames, allVariableNames])
 
 	return (

--- a/src/useMCMCMonitor.ts
+++ b/src/useMCMCMonitor.ts
@@ -15,7 +15,7 @@ export const useMCMCMonitor = () => {
     }, [dispatch])
 
     const setChainsForRun = useCallback((runId: string, chains: MCMCChain[]) => {
-        dispatch({ type: 'setChainsForRun', runId, chains })
+        dispatch({ type: 'updateChainsForRun', runId, chains })
     }, [dispatch])
 
     const setSelectedVariableNames = useCallback((variableNames: string[]) => {


### PR DESCRIPTION
Fix #36 

This PR implements two fixes for the ticketed problem, and incidentally updates the lint config to stop bothering us about the `while(true)` idiom.

### Fix 1

As mentioned in the issue ticket, the root cause of this problem was a `useEffect` hook in `RunControlPanel.tsx` which updated the selected variable names. This was intended to fire only on switching to a new run, so that `lp__` would always be selected by default if it exists, but the complete variable name list was getting updated. That in turn was because the list of `chainsForRun` from the cache was updating too often, which ultimately turned out to be a bug in the service side--`ChainFile.ts` was considering a 0-length read (such as an attempt to read past the end of a file) as a success, which meant it was both updating the chain timestamp and pushing the file pointer. Also connected to this, the `useMCMCMonitor.tsx` hook had not been updated to use the `updateChains` verb (which actually skips the update unless there are unrecognized or newer incoming chains from the API request).

Fixing these issues were enough to stop the excessive resets on the variable selection for static data. However, that wouldn't handle the case where the chains are actually updating. For that, we have fix number 2: changes to the `RunControlPanel.tsx` component. The component still recomputes the variable names every time the chains update. But this PR adds a stateful copy of the known variable names and compares that against the newly computed ones; if the observed list doesn't change, then no action occurs to reset the selection. I'm not worried about this comparison being expensive, especially since the other fix greatly reduces the frequency of recomputing variable names.

### Fix 2

The second fix would be enough to correct the underlying issue in itself, however it's good that we caught the file read issue: it was moving the "last-read" file pointer, so certain combinations of refresh rate and live-process output could have resulted in skipping a few bytes from new records, which would give weird results.

### Testing conducted:

- Add console log comments to determine when update hooks are firing
- Fix the eager-timestamp-update bug
- Confirm that manual refresh & automatic refresh no longer changes the selection state
- Temporarily reset eager-timestamp-update bug (to simulate live output to an existing chain file)
- Implement fix 2 and confirm it still fixes the issue
- Re-activate fix for eager-timestamp-update bug

### Open items:

The following code:
```typescript
	useEffect(() => {
		// start with just lp__ selected
        if (knownVariableNames.includes('lp__')) {
            setSelectedVariableNames(['lp__'])
        } else {
            setSelectedVariableNames([])
        }
	}, [runId, setSelectedVariableNames, knownVariableNames])
```
from `RunControlPanel.tsx` could theoretically remove the dependency on `runId`, as it should be present transitively through the dependency on `knownVariableNames`. However, this would result in the selected variables remaining the same when switching between runs if the chains happened to have the same set of variable names present.