### PR TITLE
Make export panel read-only.

### DIFF
--- a/src/components/ExportTab.tsx
+++ b/src/components/ExportTab.tsx
@@ -34,7 +34,7 @@ const ExportTab: FunctionComponent<Props> = () => {
 	}, [selectedVariableNames, sequences, selectedChainIds, runId])
 	return (
 		<div>
-			<textarea style={{width: '90%', maxWidth: 1000, height: 500}} value={csvText} />
+			<textarea style={{width: '90%', maxWidth: 1000, height: 500}} value={csvText} readOnly={true} />
 		</div>
 	)
 }


### PR DESCRIPTION
Fix #42 

Making it readonly did not break the ability to select-all with ctrl+a (at least on Chrome and Firefox), so this is just a one-liner.