### PR TITLE
handle websocket error

### DIFF
--- a/service/src/networking/OutgoingProxyConnection.ts
+++ b/service/src/networking/OutgoingProxyConnection.ts
@@ -62,6 +62,12 @@ class OutgoingProxyConnection {
             this.#webSocket = undefined
             this.#acknowledged = false
         })
+        ws.on('error', err => {
+            console.error(err)
+            console.warn('Websocket error.')
+            this.#webSocket = undefined
+            this.#acknowledged = false
+        })
         ws.on('message', msg => {                
             const messageJson = msg.toString()
             let message: any


### PR DESCRIPTION
Adds an error handler to the outgoing websocket connection. Addresses the error shown in the below screenshot.

Note that the keepAlive loop will try to attempt to re-establish the connection after around 20 seconds.

![image](https://user-images.githubusercontent.com/3679296/235448681-151516c2-b00e-4ec8-85e8-d93e90833e9f.png)
