### PR TITLE
Fallback to http when no webrtc connection

### DIFF
--- a/service/src/networking/OutgoingProxyConnection.ts
+++ b/service/src/networking/OutgoingProxyConnection.ts
@@ -1,10 +1,8 @@
 import WebSocket from 'ws'
 import OutputManager from '../logic/OutputManager'
-import { isAcknowledgeMessageToService, isMCMCMonitorRequest, isRequestFromClient } from '../types'
-import { InitializeMessageFromService, PingMessageFromService, RequestFromClient, ResponseToClient } from '../types/ConnectorHttpProxyTypes'
-import { MCMCMonitorResponse } from '../types/MCMCMonitorRequestTypes'
-import { handleApiRequest } from './handleApiRequest'
+import { InitializeMessageFromService, MCMCMonitorResponse, PingMessageFromService, RequestFromClient, ResponseToClient, isAcknowledgeMessageToService, isMCMCMonitorRequest, isRequestFromClient } from '../types'
 import SignalCommunicator from './SignalCommunicator'
+import { handleApiRequest } from './handleApiRequest'
 
 const proxyUrl = process.env['MCMC_MONITOR_PROXY'] || `https://mcmc-monitor-proxy.herokuapp.com`
 const proxySecret = process.env['MCMC_MONITOR_PROXY_SECRET'] || 'mcmc-monitor-no-secret'

--- a/service/src/networking/OutgoingProxyConnection.ts
+++ b/service/src/networking/OutgoingProxyConnection.ts
@@ -1,7 +1,8 @@
 import WebSocket from 'ws'
 import OutputManager from '../logic/OutputManager'
-import { InitializeMessageFromService, isAcknowledgeMessageToService, isRequestFromClient, PingMessageFromService, RequestFromClient, ResponseToClient } from '../types/ConnectorHttpProxyTypes'
-import { isMCMCMonitorRequest, MCMCMonitorResponse } from '../types/MCMCMonitorRequestTypes'
+import { isAcknowledgeMessageToService, isMCMCMonitorRequest, isRequestFromClient } from '../types'
+import { InitializeMessageFromService, PingMessageFromService, RequestFromClient, ResponseToClient } from '../types/ConnectorHttpProxyTypes'
+import { MCMCMonitorResponse } from '../types/MCMCMonitorRequestTypes'
 import { handleApiRequest } from './handleApiRequest'
 import SignalCommunicator from './SignalCommunicator'
 

--- a/service/src/networking/RemotePeer.ts
+++ b/service/src/networking/RemotePeer.ts
@@ -1,7 +1,7 @@
 import SimplePeer from 'simple-peer';
 import wrtc from 'wrtc';
 import OutputManager from '../logic/OutputManager';
-import { MCMCMonitorPeerResponse } from '../types/MCMCMonitorPeerRequestTypes';
+import { MCMCMonitorPeerResponse, isMCMCMonitorPeerRequest } from '../types';
 import SignalCommunicator, { SignalCommunicatorConnection } from './SignalCommunicator';
 import { handleApiRequest } from './handleApiRequest';
 import { isMCMCMonitorPeerRequest } from '../types';

--- a/service/src/networking/RemotePeer.ts
+++ b/service/src/networking/RemotePeer.ts
@@ -1,9 +1,10 @@
 import SimplePeer from 'simple-peer';
 import wrtc from 'wrtc';
 import OutputManager from '../logic/OutputManager';
-import { MCMCMonitorPeerResponse, isMCMCMonitorPeerRequest } from '../types/MCMCMonitorPeerRequestTypes';
+import { MCMCMonitorPeerResponse } from '../types/MCMCMonitorPeerRequestTypes';
 import SignalCommunicator, { SignalCommunicatorConnection } from './SignalCommunicator';
 import { handleApiRequest } from './handleApiRequest';
+import { isMCMCMonitorPeerRequest } from '../types';
 
 
 type callbackProps = {

--- a/service/src/networking/Server.ts
+++ b/service/src/networking/Server.ts
@@ -5,11 +5,11 @@ import fs from 'fs';
 import * as http from 'http';
 import YAML from 'js-yaml';
 import OutputManager from '../logic/OutputManager';
-import { isMCMCMonitorRequest, protocolVersion } from '../types/MCMCMonitorRequestTypes';
 import OutgoingProxyConnection from './OutgoingProxyConnection';
 import getPeer from './RemotePeer';
 import SignalCommunicator, { sleepMsec } from './SignalCommunicator';
 import { handleApiRequest } from './handleApiRequest';
+import { isMCMCMonitorRequest, protocolVersion } from '../types';
 
 const allowedOrigins = ['https://flatironinstitute.github.io', 'http://127.0.0.1:5173', 'http://localhost:5173']
 const PATH_TO_PACKAGE_JSON = '../../package.json'

--- a/service/src/networking/handleApiRequest.ts
+++ b/service/src/networking/handleApiRequest.ts
@@ -1,6 +1,5 @@
 import OutputManager from "../logic/OutputManager";
-import { isGetChainsForRunRequest, isGetRunsRequest, isGetSequencesRequest, isProbeRequest, isWebrtcSignalingRequest, protocolVersion } from "../types";
-import { GetChainsForRunRequest, GetChainsForRunResponse, GetRunsResponse, GetSequencesRequest, GetSequencesResponse, MCMCMonitorRequest, MCMCMonitorResponse, ProbeResponse, WebrtcSignalingRequest, WebrtcSignalingResponse } from "../types/MCMCMonitorRequestTypes";
+import { GetChainsForRunRequest, GetChainsForRunResponse, GetRunsResponse, GetSequencesRequest, GetSequencesResponse, MCMCMonitorRequest, MCMCMonitorResponse, ProbeResponse, WebrtcSignalingRequest, WebrtcSignalingResponse, isGetChainsForRunRequest, isGetRunsRequest, isGetSequencesRequest, isProbeRequest, isWebrtcSignalingRequest, protocolVersion } from "../types";
 import SignalCommunicator from "./SignalCommunicator";
 
 type apiRequestOptions = {

--- a/service/src/networking/handleApiRequest.ts
+++ b/service/src/networking/handleApiRequest.ts
@@ -1,5 +1,6 @@
 import OutputManager from "../logic/OutputManager";
-import { GetChainsForRunRequest, GetChainsForRunResponse, GetRunsResponse, GetSequencesRequest, GetSequencesResponse, MCMCMonitorRequest, MCMCMonitorResponse, ProbeResponse, WebrtcSignalingRequest, WebrtcSignalingResponse, isGetChainsForRunRequest, isGetRunsRequest, isGetSequencesRequest, isProbeRequest, isWebrtcSignalingRequest, protocolVersion } from "../types/MCMCMonitorRequestTypes";
+import { isGetChainsForRunRequest, isGetRunsRequest, isGetSequencesRequest, isProbeRequest, isWebrtcSignalingRequest, protocolVersion } from "../types";
+import { GetChainsForRunRequest, GetChainsForRunResponse, GetRunsResponse, GetSequencesRequest, GetSequencesResponse, MCMCMonitorRequest, MCMCMonitorResponse, ProbeResponse, WebrtcSignalingRequest, WebrtcSignalingResponse } from "../types/MCMCMonitorRequestTypes";
 import SignalCommunicator from "./SignalCommunicator";
 
 type apiRequestOptions = {

--- a/src/networking/postApiRequest.ts
+++ b/src/networking/postApiRequest.ts
@@ -2,11 +2,13 @@ import { MCMCMonitorRequest, MCMCMonitorResponse, isMCMCMonitorResponse } from "
 import { serviceBaseUrl, useWebrtc, webrtcConnectionToService } from "../config"
 
 const postApiRequest = async (request: MCMCMonitorRequest): Promise<MCMCMonitorResponse> => {
+    // Note: we always use http for probe requests and webrtc signaling requests
     if ((useWebrtc) && (request.type !== 'probeRequest') && (request.type !== 'webrtcSignalingRequest')) {
-        if (!webrtcConnectionToService) {
-            throw Error('No webrtc connection to service')
+        if (webrtcConnectionToService) {
+            // if we have a webrtc connection, post the request via webrtc
+            return webrtcConnectionToService.postApiRequest(request)
         }
-        return webrtcConnectionToService.postApiRequest(request)
+        // if no webrtc connection, fall through to fetch via http below
     }
     const rr = await fetch(
         `${serviceBaseUrl}/api`,

--- a/test/networking/postApiRequest.test.ts
+++ b/test/networking/postApiRequest.test.ts
@@ -82,12 +82,22 @@ describe("Post API Request function", () => {
         expect(nonProbeResponse).toBe(webrtcMockResponse)
     })
 
-    test("postApiRequest webrtc throws if invalid connection to service", async () => {
+    test("postApiRequest webrtc falls back to http if service connection is invalid", async () => {
+        const myFetch = vi.fn(fetchFactory())
+        global.fetch = myFetch
         mockConfig(true, true)
         const postApiRequest = await importFunctionUnderTest()
-        await expect(() => postApiRequest(myNonProbeRequest)).rejects.toThrow(/No webrtc connection/)
-        vi.spyOn(console, 'warn').mockRestore()
+        const resp = await postApiRequest(myNonProbeRequest)
+        expect(myFetch).toHaveBeenCalledOnce()
+        expect(isMCMCMonitorResponse(resp)).toBeTruthy()
     })
+
+    // test("postApiRequest webrtc throws if invalid connection to service", async () => {
+    //     mockConfig(true, true)
+    //     const postApiRequest = await importFunctionUnderTest()
+    //     await expect(() => postApiRequest(myNonProbeRequest)).rejects.toThrow(/No webrtc connection/)
+    //     vi.spyOn(console, 'warn').mockRestore()
+    // })
 
     test("postApiRequest with webrtc uses non-webrtc for probe or signaling request", async () => {
         const myFetch = vi.fn(fetchFactory())


### PR DESCRIPTION
I have found that webrtc does not always work. In rtcshare, even though using a TURN server helps, it does not seem to solve the problem in all cases. I think it is most important that the system works and the page loads than insisting on using webrtc, even if it means some demand on our heroku proxy server. We have 2TB per month bandwidth, so that should be good for now, I believe. We can work on solving this problem down the road.

@jsoules what do you think?

Note: #53 should be merged first.