### PR TITLE
Make wrtc an optional dependency

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -7,7 +7,7 @@
     "mcmc-monitor": "./bin/mcmc-monitor"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp package.json dist/",
     "dev": "nodemon src/index.ts start --v --dir ../examples/example-output --enable-remote-access",
     "start-demo": "node src/index.ts start --v --dir ./example-output",
     "release": "yarn build && yarn coverage && npm publish && git tag $npm_package_version && git push --tags",

--- a/service/package.json
+++ b/service/package.json
@@ -35,9 +35,11 @@
     "js-yaml": "^4.1.0",
     "simple-peer": "^9.11.1",
     "ts-node": "^10.9.1",
-    "wrtc": "^0.4.7",
     "ws": "^8.12.0",
     "yargs": "^17.6.2"
+  },
+  "optionalDependencies": {
+    "wrtc": "^0.4.7"
   },
   "engines": {
     "node": ">= 16.0.0"

--- a/service/src/networking/RemotePeer.ts
+++ b/service/src/networking/RemotePeer.ts
@@ -1,5 +1,4 @@
 import SimplePeer from 'simple-peer';
-import wrtc from 'wrtc';
 import OutputManager from '../logic/OutputManager';
 import { MCMCMonitorPeerResponse, isMCMCMonitorPeerRequest } from '../types';
 import SignalCommunicator, { SignalCommunicatorConnection } from './SignalCommunicator';
@@ -15,7 +14,18 @@ type callbackProps = {
 }
 
 
-const getPeer = (connection: SignalCommunicatorConnection, outputMgr: OutputManager, signalCommunicator: SignalCommunicator) => {
+const createPeer = async (connection: SignalCommunicatorConnection, outputMgr: OutputManager, signalCommunicator: SignalCommunicator): Promise<SimplePeer.Instance | undefined> => {
+    // wrtc is a conditional dependency (doesn't install on some versions of mac os). If it's not available, we can't use webrtc.
+    let wrtc: any
+    try {
+        wrtc = await import('wrtc')
+    }
+    catch(err) {
+        console.error(err)
+        console.warn('Problem importing wrtc. Falling back to non-webrtc connection.')
+        return undefined
+    }
+
     const peer = new SimplePeer({initiator: false, wrtc})
     const id = Math.random().toString(36).substring(2, 10)
     const props: callbackProps = {
@@ -113,4 +123,4 @@ const onConnectionSignal = (signal: string, props: callbackProps) => {
 }
 
 
-export default getPeer
+export default createPeer

--- a/service/src/networking/Server.ts
+++ b/service/src/networking/Server.ts
@@ -6,7 +6,7 @@ import * as http from 'http';
 import YAML from 'js-yaml';
 import OutputManager from '../logic/OutputManager';
 import OutgoingProxyConnection from './OutgoingProxyConnection';
-import getPeer from './RemotePeer';
+import createPeer from './RemotePeer';
 import SignalCommunicator, { sleepMsec } from './SignalCommunicator';
 import { handleApiRequest } from './handleApiRequest';
 import { isMCMCMonitorRequest, protocolVersion } from '../types';
@@ -49,7 +49,7 @@ class Server {
         })
         const signalCommunicator = new SignalCommunicator()
         if (a.enableRemoteAccess) {
-            signalCommunicator.onConnection(connection => { return getPeer(connection, this.#outputManager, signalCommunicator)})
+            signalCommunicator.onConnection(async connection => {createPeer(connection, this.#outputManager, signalCommunicator)})
         }
         const urlLocal = `https://flatironinstitute.github.io/mcmc-monitor?s=http://localhost:${this.a.port}`
         console.info('')

--- a/service/src/networking/Server.ts
+++ b/service/src/networking/Server.ts
@@ -62,7 +62,16 @@ class Server {
                 const outgoingProxyConnection = new OutgoingProxyConnection(publicId, privateId, this.#outputManager, signalCommunicator, {verbose: this.a.verbose, webrtc: true})
                 this.#outgoingProxyConnection = outgoingProxyConnection
                 const proxyUrl = outgoingProxyConnection.url
-                const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=1`
+                let canImportWrtc: boolean
+                try {
+                    await import('wrtc')
+                    canImportWrtc = true
+                }
+                catch(err) {
+                    console.warn('Unable to import wrtc')
+                    canImportWrtc = false
+                }
+                const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=${canImportWrtc ? "1" : "0"}`
                 console.info('')
                 console.info(`Connect on remote machine: ${urlRemote}`)
                 console.info('')

--- a/service/src/networking/SignalCommunicator.ts
+++ b/service/src/networking/SignalCommunicator.ts
@@ -1,4 +1,4 @@
-import { WebrtcSignalingRequest, WebrtcSignalingResponse } from "../types/MCMCMonitorRequestTypes";
+import { WebrtcSignalingRequest, WebrtcSignalingResponse } from "../types";
 
 class SignalCommunicator {
     #onConnectionCallbacks: ((connection: SignalCommunicatorConnection) => Promise<void>)[] = []
@@ -12,9 +12,7 @@ class SignalCommunicator {
                     delete this.#connections[request.clientId]
                 }
             })
-            for (const cb of this.#onConnectionCallbacks) {
-                await cb(cc)
-            }
+            await Promise.all(this.#onConnectionCallbacks.map(cb => cb(cc)))
         }
         return await this.#connections[request.clientId].handleRequest(request)
     }

--- a/service/src/networking/SignalCommunicator.ts
+++ b/service/src/networking/SignalCommunicator.ts
@@ -1,7 +1,7 @@
 import { WebrtcSignalingRequest, WebrtcSignalingResponse } from "../types/MCMCMonitorRequestTypes";
 
 class SignalCommunicator {
-    #onConnectionCallbacks: ((connection: SignalCommunicatorConnection) => void)[] = []
+    #onConnectionCallbacks: ((connection: SignalCommunicatorConnection) => Promise<void>)[] = []
     #connections: {[clientId: string]: SignalCommunicatorConnection} = {}
     async handleRequest(request: WebrtcSignalingRequest): Promise<WebrtcSignalingResponse> {
         if (!(request.clientId in this.#connections)) {
@@ -12,11 +12,13 @@ class SignalCommunicator {
                     delete this.#connections[request.clientId]
                 }
             })
-            this.#onConnectionCallbacks.forEach(cb => {cb(cc)})
+            for (const cb of this.#onConnectionCallbacks) {
+                await cb(cc)
+            }
         }
         return await this.#connections[request.clientId].handleRequest(request)
     }
-    onConnection(cb: (connection: SignalCommunicatorConnection) => void) {
+    onConnection(cb: (connection: SignalCommunicatorConnection) => Promise<void>) {
         this.#onConnectionCallbacks.push(cb)
     }
 }


### PR DESCRIPTION
To address #50 

Makes wrtc package an optional dependency (optionalDependencies in package.json)
See: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#optionaldependencies

Of course then at run time we'll need to detect whether we can import wrtc.

In order to do this, I needed to use the dynamic async import mechanism
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import

This required that one function becomes async, which required some minor tweaks.

For testing... I realized it's not possible to test this in the dev version because wrtc is needed in node_modules in order for the typescript compiler to create the dist. So instead I built it (yarn build), manually removed wrtc from node_modules, and then ran the built version using `node dist/index.js start ...`. This seemed to work -- i.e., it reported that it was not able to load wrtc, and carried on anyway. Great!

In doing the above, I discovered there was a packaging issue introduced in some of the recent changes. Server.ts now loads data from the ../../package.json file, but that wasn't getting copied to dist/ folder. So I updated the build command in package.json to copy that file over.

Finally, for the case of remote access with wrtc not loading, I modified Server.ts to print webrtc=0 in the output URL if it detected that wrtc could not be imported.
