### PR TITLE
Refactor gui-side webrtc networking code, adding tests.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import SimplePeer from "simple-peer"
 import WebrtcConnectionToService from "./networking/WebrtcConnectionToService"
 
 const urlSearchParams = new URLSearchParams(window.location.search)
@@ -18,5 +19,7 @@ export const useWebrtc = queryParams.webrtc === '1'
 export let webrtcConnectionToService: WebrtcConnectionToService | undefined
 
 if ((useWebrtc) && (!webrtcConnectionToService)) {
-    webrtcConnectionToService = new WebrtcConnectionToService()
+    const peerInstance = new SimplePeer({initiator: true})
+    webrtcConnectionToService = new WebrtcConnectionToService(peerInstance).configurePeer()
+    webrtcConnectionToService?.connect()
 }

--- a/src/networking/WebrtcConnectionToService.ts
+++ b/src/networking/WebrtcConnectionToService.ts
@@ -1,5 +1,7 @@
 import SimplePeer from "simple-peer";
 import { MCMCMonitorPeerRequest, MCMCMonitorRequest, MCMCMonitorResponse, WebrtcSignalingRequest, isMCMCMonitorPeerResponse } from "../../service/src/types";
+import randomAlphaString from "../util/randomAlphaString";
+import sleepMsec from "../util/sleepMsec";
 import postApiRequest from "./postApiRequest";
 
 class WebrtcConnectionToService {
@@ -95,26 +97,6 @@ class WebrtcConnectionToService {
     public get status() {
         return this.#status
     }
-}
-
-export const randomAlphaString = (num_chars: number) => {
-    if (!num_chars) {
-        throw Error('randomAlphaString: num_chars needs to be a positive integer.')
-    }
-    let text = ""
-    const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    for (let i = 0; i < num_chars; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length))
-    }
-    return text
-}
-
-export const sleepMsec = async (msec: number): Promise<void> => {
-    return new Promise<void>((resolve) => {
-        setTimeout(() => {
-            resolve()
-        }, msec)
-    })
 }
 
 export default WebrtcConnectionToService

--- a/src/networking/WebrtcConnectionToService.ts
+++ b/src/networking/WebrtcConnectionToService.ts
@@ -4,28 +4,31 @@ import randomAlphaString from "../util/randomAlphaString";
 import sleepMsec from "../util/sleepMsec";
 import postApiRequest from "./postApiRequest";
 
+type webrtcConnectionStatus = 'pending' | 'connected' | 'error'
+
+export const WEBRTC_CONNECTION_RETRY_INTERVAL_MS = 3000
+export const WEBRTC_CONNECTION_TIMEOUT_INTERVAL_MS = 15000
+export const WEBRTC_CONNECTION_PENDING_API_WAIT_INTERVAL_MS = 100
+
+type callbacksQueueType = {[requestId: string]: (response: MCMCMonitorResponse) => void}
+
 class WebrtcConnectionToService {
     #peer: SimplePeer.Instance | undefined
-    #requestCallbacks: {[requestId: string]: (response: MCMCMonitorResponse) => void} = {}
-    #status: 'pending' | 'connected' | 'error' = 'pending'
-    constructor() {
-        const clientId = randomAlphaString(10)
-        const peer = new SimplePeer({initiator: true})
-        peer.on('signal', async s => {
-            const request: WebrtcSignalingRequest = {
-                type: 'webrtcSignalingRequest',
-                clientId,
-                signal: JSON.stringify(s)
-            }
-            const response = await postApiRequest(request)
-            if (response.type !== 'webrtcSignalingResponse') {
-                console.warn(response)
-                throw Error('Unexpected webrtc signaling response')
-            }
-            for (const sig0 of response.signals) {
-                peer.signal(sig0)
-            }
-        })
+    #requestCallbacks: callbacksQueueType = {}
+    #clientId = 'ID-PENDING'
+    #status: webrtcConnectionStatus = 'pending'
+    constructor(peer: SimplePeer.Instance, callbacksQueue?: callbacksQueueType) {
+        this.#clientId = randomAlphaString(10)
+        this.#peer = peer
+        this.#requestCallbacks = callbacksQueue ?? {}
+    }
+    configurePeer() {
+        if (this.#peer === undefined) {
+            console.warn(`Attempt to configure uninitialized peer.`)
+            return this
+        }
+        const peer = this.#peer
+        peer.on('signal', async s => sendWebrtcSignal(this.#clientId, peer, s))
         peer.on('connect', () => {
             console.info('Webrtc connection established')
             this.#status = 'connected'
@@ -44,42 +47,35 @@ class WebrtcConnectionToService {
             delete this.#requestCallbacks[dd.requestId]
             cb(dd.response)
         })
-        this.#peer = peer
-        ;(async () => {
-            const timer = Date.now()
-            while (this.#status === 'pending') {
-                const elapsed = Date.now() - timer
-                if (elapsed > 15000) {
-                    this.#status = 'error'
-                    console.warn('Unable to establish webrtc connection.')
-                    break   
-                }
-                await sleepMsec(3000)
-                if (this.#status === 'pending') {
-                    const request: WebrtcSignalingRequest = {
-                        type: 'webrtcSignalingRequest',
-                        clientId,
-                        signal: undefined
-                    }
-                    const response = await postApiRequest(request)
-                    if (response.type !== 'webrtcSignalingResponse') {
-                        throw Error('Unexpected webrtc signaling response')
-                    }
-                    for (const sig0 of response.signals) {
-                        peer.signal(sig0)
-                    }
-                }
+        return this
+    }
+    async connect() {
+        if (this.#peer === undefined) {
+            console.warn("Attempt to connect using uninitialized SimplePeer instance.")
+            return
+        }
+        const timer = Date.now()
+        while (this.#status === 'pending') {
+            const elapsed = Date.now() - timer
+            if (elapsed > WEBRTC_CONNECTION_TIMEOUT_INTERVAL_MS) {
+                this.#status = 'error'
+                console.warn('Unable to establish webrtc connection.')
+                break   
             }
-        })()
+            await sleepMsec(WEBRTC_CONNECTION_RETRY_INTERVAL_MS)
+            if (this.#status === 'pending') {
+                sendWebrtcSignal(this.#clientId, this.#peer, undefined)
+            }
+        }
     }
     async postApiRequest(request: MCMCMonitorRequest): Promise<MCMCMonitorResponse> {
+        if (!this.#peer) throw Error('No peer')
         if (this.status === 'error') {
             throw Error('Error in webrtc connection')
         }
         while (this.status === 'pending') {
-            await sleepMsec(100)
+            await sleepMsec(WEBRTC_CONNECTION_PENDING_API_WAIT_INTERVAL_MS)
         }
-        if (!this.#peer) throw Error('No peer')
         const peer = this.#peer
         const requestId = randomAlphaString(10)
         const rr: MCMCMonitorPeerRequest = {
@@ -96,6 +92,28 @@ class WebrtcConnectionToService {
     }
     public get status() {
         return this.#status
+    }
+    public get clientId() {
+        return this.#clientId
+    }
+    public setErrorStatus() {
+        this.#status = 'error'
+    }
+}
+
+export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instance, s: SimplePeer.SignalData | undefined) => {
+    const request: WebrtcSignalingRequest = {
+        type: 'webrtcSignalingRequest',
+        clientId,
+        signal: s === undefined ? undefined : JSON.stringify(s)
+    }
+    const response = await postApiRequest(request)
+    if (response.type !== 'webrtcSignalingResponse') {
+        console.warn(response)
+        throw Error('Unexpected webrtc signaling response')
+    }
+    for (const sig0 of response.signals) {
+        peer.signal(sig0)
     }
 }
 

--- a/src/util/randomAlphaString.ts
+++ b/src/util/randomAlphaString.ts
@@ -1,5 +1,5 @@
 const randomAlphaString = (num_chars: number) => {
-    if (!num_chars) {
+    if (!num_chars || num_chars < 0) {
         throw Error('randomAlphaString: num_chars needs to be a positive integer.')
     }
     let text = ""

--- a/src/util/randomAlphaString.ts
+++ b/src/util/randomAlphaString.ts
@@ -1,0 +1,13 @@
+const randomAlphaString = (num_chars: number) => {
+    if (!num_chars) {
+        throw Error('randomAlphaString: num_chars needs to be a positive integer.')
+    }
+    let text = ""
+    const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    for (let i = 0; i < num_chars; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length))
+    }
+    return text
+}
+
+export default randomAlphaString

--- a/src/util/sleepMsec.ts
+++ b/src/util/sleepMsec.ts
@@ -1,0 +1,9 @@
+const sleepMsec = async (msec: number): Promise<void> => {
+    return new Promise<void>((resolve) => {
+        setTimeout(() => {
+            resolve()
+        }, msec)
+    })
+}
+
+export default sleepMsec

--- a/test/networking/WebrtcConnectionToService.test.ts
+++ b/test/networking/WebrtcConnectionToService.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+
+// need to mock:
+// postApiRequest
+// SimplePeer
+// Date.now() timer
+
+describe("WebrtcConnectionToService embedded peer", () => {
+    test("Connection object instantiates peer as part of construction", () => {
+
+    })
+    test("Instantiated peer responds to signal event", () => {
+
+    })
+    test("Instantiated peer posts a signaling request on signal event", () => {
+
+    })
+    test("Instantiated peer throws on bad signaling response", () => {
+
+    })
+    test("Instantiated peer handles connect event", () => {
+
+    })
+    test("Instantiated peer listens for data event", () => {
+
+    })
+    test("Instantiated peer throws on bad data event response", () => {
+
+    })
+    test("Instantiated peer warns on peer data response with no matching ID", () => {
+
+    })
+    test("Instantiated peer calls and deletes ID-matched callback on data response", () => {
+        
+    })
+})
+
+describe("WebrtcConnectionToService upon-construction peer connection", () => {
+    test("Connection object attempts to connect on construction", () => {
+
+    })
+    test("Connection object times out after 15 seconds", () => {
+
+    })
+    test("Connection object throws on wrong response type", () => {
+
+    })
+    test("Connection object responds to all received signals", () => {
+
+    })
+})
+
+describe("GUI web rtc connection post api request", () => {
+
+})
+
+describe("GUI web rtc connection status function", () => {
+    test("Returns connection's current status", () => {
+        expect(1).toBe(1)
+    })
+})

--- a/test/networking/WebrtcConnectionToService.test.ts
+++ b/test/networking/WebrtcConnectionToService.test.ts
@@ -1,61 +1,361 @@
-import { describe, expect, test } from 'vitest'
+import SimplePeer from 'simple-peer'
+import { Mock, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { MCMCMonitorRequest, MCMCMonitorResponse, ProbeRequest } from '../../service/src/types'
 
-// need to mock:
-// postApiRequest
-// SimplePeer
-// Date.now() timer
+type apiEndpoint = (request: MCMCMonitorRequest) => Promise<MCMCMonitorResponse>
 
-describe("WebrtcConnectionToService embedded peer", () => {
-    test("Connection object instantiates peer as part of construction", () => {
 
+class MockWorkingPeer {
+    signalCallbacks: any[]
+    connectCallbacks: any[]
+    dataCallbacks: any[]
+    initiator
+    send
+    constructor(initiator: boolean) {
+        this.initiator = initiator
+        this.signalCallbacks = []
+        this.connectCallbacks = []
+        this.dataCallbacks = []
+        this.send = vi.fn()
+    }
+    on(type: string, cb: any) {
+        switch(type) {
+            case 'signal':
+                this.signalCallbacks.push(cb)
+                break
+            case 'connect':
+                this.connectCallbacks.push(cb)
+                break
+            case 'data':
+                this.dataCallbacks.push(cb)
+                break
+            default:
+                throw Error(`Bad cb stack in mock simple peer: ${type}`)
+        }
+    }
+    signal(s: any) {
+        this.signalCallbacks.forEach(cb => cb(s))
+    }
+    connect() {
+        this.connectCallbacks.forEach(cb => cb())
+    }
+    data(d: any) {
+        this.dataCallbacks.forEach(cb => cb(d))
+    }
+}
+
+
+describe("web rtc signal transmission function", () => {
+    const clientId = "my-client-id"
+    let mockPeer: { signal: Mock<any, any> }
+    let mockPostApiRequest: Mock
+
+    beforeEach(() => {
+        mockPeer = { signal: vi.fn() }
+        mockPostApiRequest = vi.fn()
+        vi.doMock('../../src/networking/postApiRequest', () => {
+            return {
+                __esModule: true,
+                default: mockPostApiRequest as unknown as apiEndpoint
+            }
+        })
     })
-    test("Instantiated peer responds to signal event", () => {
-
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.resetModules()
     })
-    test("Instantiated peer posts a signaling request on signal event", () => {
+    test("Sends appropriately constituted request", async () => {
+        mockPostApiRequest.mockResolvedValue({ type: 'webrtcSignalingResponse', signals: [] })
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).sendWebrtcSignal
+        await sut(clientId, mockPeer as any as SimplePeer.Instance, undefined)
+        expect(mockPostApiRequest).toHaveBeenCalledOnce()
+        const req = mockPostApiRequest.mock.lastCall[0]
+        expect(req.type).toBe("webrtcSignalingRequest")
+        expect(req.clientId).toBe(clientId)
+        expect(req.signal).toBeUndefined()
 
+        const myData = { "data": "value" }
+        await sut(clientId, mockPeer as unknown as SimplePeer.Instance, myData as unknown as SimplePeer.SignalData)
+        expect(mockPostApiRequest).toHaveBeenCalledTimes(2)
+        const req2 = mockPostApiRequest.mock.lastCall[0]
+        expect(req2.type).toBe("webrtcSignalingRequest")
+        expect(req2.clientId).toBe(clientId)
+        expect(req2.signal).toEqual(JSON.stringify(myData))
     })
-    test("Instantiated peer throws on bad signaling response", () => {
-
+    test("Throws on non-webrtcSignalingResponse response", async () => {
+        mockPostApiRequest.mockResolvedValue({type: 'Surprise!'})
+        vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).sendWebrtcSignal
+        expect(() => sut(clientId, mockPeer as any as SimplePeer.Instance, undefined)).rejects.toThrow(/Unexpected webrtc signaling response/)
     })
-    test("Instantiated peer handles connect event", () => {
-
-    })
-    test("Instantiated peer listens for data event", () => {
-
-    })
-    test("Instantiated peer throws on bad data event response", () => {
-
-    })
-    test("Instantiated peer warns on peer data response with no matching ID", () => {
-
-    })
-    test("Instantiated peer calls and deletes ID-matched callback on data response", () => {
-        
+    test("Calls peer signal method on received response signals", async () => {
+        const signals = ['signal 1', 'signal 2']
+        mockPostApiRequest.mockResolvedValue({type: 'webrtcSignalingResponse', signals})
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).sendWebrtcSignal
+        await sut(clientId, mockPeer as any as SimplePeer.Instance, undefined)
+        expect(mockPeer.signal).toHaveBeenCalledTimes(2)
+        mockPeer.signal.mock.calls.forEach((c, i) => expect(c[0]).toEqual(signals[i]))
     })
 })
 
-describe("WebrtcConnectionToService upon-construction peer connection", () => {
-    test("Connection object attempts to connect on construction", () => {
 
+describe("WebrtcConnectionToService peer configuration", () => {
+    let mockPostApiRequest: Mock
+    let mockPeer: MockWorkingPeer
+
+    beforeEach(() => {
+        mockPeer = new MockWorkingPeer(true)
+        mockPostApiRequest = vi.fn()
+        vi.doMock('../../src/networking/postApiRequest', () => {
+            return {
+                __esModule: true,
+                default: mockPostApiRequest as unknown as apiEndpoint
+            }
+        })
     })
-    test("Connection object times out after 15 seconds", () => {
-
+    afterEach(() => {
+        vi.resetAllMocks()
+        vi.resetModules()
     })
-    test("Connection object throws on wrong response type", () => {
 
+    test("Peer configuration warns on undefined peer", async () => {
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        const cnxn = new sut(undefined as unknown as SimplePeer.Instance)
+        const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        cnxn.configurePeer()
+        expect(mockWarn).toBeCalledTimes(1)
+        vi.spyOn(console, 'warn').mockRestore()
     })
-    test("Connection object responds to all received signals", () => {
+    test("Instantiated peer responds to signal event", async () => {
+        const mySignal = {s: 'mySignal'}
+        mockPostApiRequest.mockResolvedValue({type: 'webrtcSignalingResponse', signals: []})
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        new sut(mockPeer as unknown as SimplePeer.Instance).configurePeer()
+        mockPeer.signal(mySignal)
+        expect(mockPostApiRequest).toHaveBeenCalledOnce()
+        const req = mockPostApiRequest.mock.lastCall[0]
+        expect(req.signal).toEqual(JSON.stringify(mySignal))
+    })
+    test("Instantiated peer handles connect event", async () => {
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        const cnxn = new sut(mockPeer as unknown as SimplePeer.Instance).configurePeer()
+        const mockInfo = vi.spyOn(console, 'info').mockImplementation(() => {})
+        mockPeer.connect()
+        expect(cnxn?.status).toEqual('connected')
+        expect(mockInfo).toBeCalledTimes(1)
+        vi.spyOn(console, 'info').mockRestore()
+    })
+    test("Instantiated peer calls and deletes ID-matched callback on data response", async () => {
+        const requestId = 'abcde'
+        const mockCallback = vi.fn()
+        const callbacks: {[requestId: string]: (response: MCMCMonitorResponse) => void} = {}
+        callbacks[requestId] = (mockCallback)
+        const myResponse = { type: 'probeResponse', protocolVersion: 'v1.0' }
+        const myPeerResponse = { type: 'mcmcMonitorPeerResponse', response: myResponse, requestId}
 
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        new sut(mockPeer as unknown as SimplePeer.Instance, callbacks).configurePeer()
+
+        expect(callbacks[requestId]).not.toBeUndefined()
+        mockPeer.data(JSON.stringify(myPeerResponse))
+        expect(callbacks[requestId]).toBeUndefined()
+        expect(mockCallback).toHaveBeenCalledOnce()
+        const call = mockCallback.mock.lastCall[0]
+        expect(call).toEqual(myResponse)
+    })
+    test("Instantiated peer throws on bad data event response", async () => {
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        new sut(mockPeer as unknown as SimplePeer.Instance).configurePeer()
+
+        const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        expect(() => mockPeer.data(JSON.stringify({type: 'Surprise!'}))).toThrow(/Unexpected peer response/)
+        expect(mockWarn).toHaveBeenCalledOnce()
+        vi.spyOn(console, 'warn').mockRestore()
+    })
+    test("Instantiated peer warns on peer data response with no matching ID", async () => {
+        const callbacks: {[requestId: string]: (response: MCMCMonitorResponse) => void} = {}
+        const myResponse = { type: 'probeResponse', protocolVersion: 'v1.0' }
+        const myPeerResponse = { type: 'mcmcMonitorPeerResponse', response: myResponse, requestId: 'surprise!'}
+        const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        new sut(mockPeer as unknown as SimplePeer.Instance, callbacks).configurePeer()
+
+        mockPeer.data(JSON.stringify(myPeerResponse))
+        expect(mockWarn).toHaveBeenCalledOnce()
+        vi.spyOn(console, 'warn').mockRestore()
+    })
+})
+
+describe("WebrtcConnectionToService peer connection", () => {
+    let mockPostApiRequest: Mock
+    let mockPeer
+
+    beforeEach(() => {
+        mockPeer = { signal: vi.fn() }
+        mockPostApiRequest = vi.fn()
+        vi.doMock('../../src/networking/postApiRequest', () => {
+            return {
+                __esModule: true,
+                default: mockPostApiRequest as unknown as apiEndpoint
+            }
+        })
+    })
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.resetModules()
+    })
+
+    test("Connecting warns if peer is undefined", async () => {
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        const cnxn = new sut(undefined as unknown as SimplePeer.Instance)
+        
+        const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        expect(cnxn.status).toEqual('pending')
+        cnxn.connect()
+        expect(spyWarn).toHaveBeenCalledOnce()
+        vi.spyOn(console, 'warn').mockRestore()
+    })
+    test("Connection object times out after 15 seconds", async () => {
+        const now = Date.now()
+        const mockDate = vi.spyOn(Date, 'now')
+        const mockWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        
+        const mockImport = (await import('../../src/networking/WebrtcConnectionToService'))
+        const sut = mockImport.default
+        mockDate.mockReturnValueOnce(now).mockReturnValueOnce(now + 1 + mockImport.WEBRTC_CONNECTION_TIMEOUT_INTERVAL_MS)
+        const cnxn = new sut(mockPeer as unknown as SimplePeer.Instance)
+        
+        expect(cnxn.status).toBe('pending')
+        cnxn.connect()
+        expect(cnxn.status).toBe('error')
+        expect(mockWarn).toHaveBeenCalledOnce()
+        expect(mockDate).toHaveBeenCalledTimes(2)
+
+        vi.spyOn(console, 'warn').mockRestore()
+        vi.spyOn(Date, 'now').mockRestore()
+    })
+    test("Connection object sleeps and resignals while in pending status", async () => {
+        const mockSleep = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('break loop'))
+        vi.doMock('../../src/util/sleepMsec', () => {
+            return {
+                __esModule: true,
+                default: mockSleep
+            }
+        })
+        mockPostApiRequest.mockResolvedValue({ type: 'webrtcSignalingResponse', signals: [] })
+        const mockImport = (await import('../../src/networking/WebrtcConnectionToService'))
+        const cnxn = new mockImport.default(mockPeer as unknown as SimplePeer.Instance)
+        
+        expect(cnxn.status).toBe('pending')
+        expect(() => cnxn.connect()).rejects.toThrow(/break loop/)
+        expect(cnxn.status).toBe('pending')
     })
 })
 
 describe("GUI web rtc connection post api request", () => {
+    let mockPostApiRequest: Mock
+    let mockPeer
 
+    beforeEach(() => {
+        // vi.useRealTimers()
+        mockPeer = new MockWorkingPeer(true)
+        mockPostApiRequest = vi.fn()
+        vi.doMock('../../src/networking/postApiRequest', () => {
+            return {
+                __esModule: true,
+                default: mockPostApiRequest as unknown as apiEndpoint
+            }
+        })
+    })
+    afterEach(() => {
+        vi.resetAllMocks()
+        vi.resetModules()
+        vi.useRealTimers()
+    })
+
+    const mockRequest = { type: 'probeRequest' } as any as ProbeRequest
+
+    test("Throws if no known peer", async () => {
+        const imported = (await import('../../src/networking/WebrtcConnectionToService'))
+        const cnxn = new imported.default(undefined as any)
+        expect(() => cnxn.postApiRequest(mockRequest)).rejects.toThrow(/No peer/)
+    })
+    test("Throws if connection is in error status", async () => {
+        const imported = (await import('../../src/networking/WebrtcConnectionToService'))
+        const cnxn = new imported.default(mockPeer)
+        expect(cnxn.status).toEqual('pending')
+        cnxn.setErrorStatus()
+        expect(cnxn.status).toEqual('error')
+        expect(() => cnxn.postApiRequest(mockRequest)).rejects.toThrow(/Error in webrtc connection/)
+    })
+    test("Waits if status is pending", async () => {
+        const mockSleep = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('break loop'))
+        vi.doMock('../../src/util/sleepMsec', () => {
+            return {
+                __esModule: true,
+                default: mockSleep
+            }
+        })
+        const imported = (await import('../../src/networking/WebrtcConnectionToService'))
+        const cnxn = new imported.default(mockPeer)
+        expect(cnxn.status).toBe('pending')
+        expect(() => cnxn.postApiRequest(mockRequest)).rejects.toThrow(/break loop/)
+        expect(mockSleep).toHaveBeenCalledOnce()
+        expect(mockSleep.mock.lastCall[0]).toEqual(imported.WEBRTC_CONNECTION_PENDING_API_WAIT_INTERVAL_MS)
+    })
+    test("Sends stringified request to peer returning promise resolved by callback fn", async () => {
+        const imported = (await import('../../src/networking/WebrtcConnectionToService'))
+        const requests = {}
+        const cnxn = new imported.default(mockPeer, requests).configurePeer()
+        mockPeer.connect()
+        mockPeer.send = vi.fn().mockResolvedValue(undefined)
+
+        expect(cnxn.status).toBe('connected')
+        expect(mockPeer.send).toHaveBeenCalledTimes(0)
+
+        const promise = cnxn.postApiRequest(mockRequest)
+        setTimeout(() => {}, 0)
+        const reqs = Object.keys(requests)
+        expect(reqs.length).toBe(1)
+        requests[reqs[0]]('foo')
+        const result = await promise
+        expect(mockPeer.send).toHaveBeenCalledOnce()
+
+        const call = mockPeer.send.mock.lastCall[0]
+        expect(call).toEqual(JSON.stringify({type: 'mcmcMonitorPeerRequest', request: mockRequest, requestId: reqs[0]}))
+        expect(result).toBe('foo')
+    })
 })
 
-describe("GUI web rtc connection status function", () => {
-    test("Returns connection's current status", () => {
-        expect(1).toBe(1)
+describe("GUI web rtc connection instantiation", () => {
+    let mockPostApiRequest: Mock
+
+    // we won't be using the postApiRequest mock for anything, but need to mock it
+    // or else set up the environment so that the window import is defined--the
+    // import chain winds up invoking browser-environment-specific globals
+    beforeEach(() => {
+        mockPostApiRequest = vi.fn()
+        vi.doMock('../../src/networking/postApiRequest', () => {
+            return {
+                __esModule: true,
+                default: mockPostApiRequest as unknown as apiEndpoint
+            }
+        })
+
+    })
+
+    test("Returns connection's current status", async () => {
+        const myPeer = {} as unknown as SimplePeer.Instance
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        const cnxn = new sut(myPeer)
+        expect(cnxn.status).toEqual('pending')
+    })
+    test("ClientID is set during construction", async () => {
+        const myPeer = {} as unknown as SimplePeer.Instance
+        const sut = (await import('../../src/networking/WebrtcConnectionToService')).default
+        const cnxn = new sut(myPeer)
+        expect(cnxn.clientId).not.toEqual("ID-PENDING")
+        expect(cnxn.clientId.length).toEqual(10)
     })
 })

--- a/test/util/randomAlphaString.test.ts
+++ b/test/util/randomAlphaString.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+import randomAlphaString from '../../src/util/randomAlphaString'
+
+describe("Random alpha string generator", () => {
+    test("Generates string of requested length", () => {
+        const len = 15
+        const txt = randomAlphaString(len)
+        expect(txt.length).toBe(len)
+    })
+    test("Throws on requested zero- or negative-length string", () => {
+        expect(() => randomAlphaString(0)).toThrow(/num_chars needs to be a positive integer/)
+        expect(() => randomAlphaString(-5)).toThrow(/num_chars needs to be a positive integer/)
+    })
+    test("Generates roughly even distribution of letters", () => {
+        const len = 10000
+        const txt = randomAlphaString(len)
+        const counts: Map<string, number> = new Map()
+        for (const char of txt) {
+            const current = counts.get(char) ?? 0
+            counts.set(char, current + 1)
+        }
+        const vals = [...counts.values()]
+        const mean = vals.reduce((a, v) => a + v, 0)/vals.length
+        expect(mean).toBeCloseTo(len / 52)
+    })
+    test("Generates different strings when called repeatedly", () => {
+        const len = 15
+        const txt1 = randomAlphaString(len)
+        const txt2 = randomAlphaString(len)
+        expect(txt1).not.toEqual(txt2)
+    })
+})

--- a/test/util/sleepMsec.test.ts
+++ b/test/util/sleepMsec.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from 'vitest'
+import sleepMsec from '../../src/util/sleepMsec'
+
+
+
+describe("Promise-oriented timeout function", () => {
+    test("Resolves to void", async () => {
+        const res = await sleepMsec(0)
+        expect(res).toBeTypeOf("undefined")
+    })
+    test("Calls resolve callback", async () => {
+        const myfn = vi.fn()
+        await sleepMsec(1).then(() => myfn())
+        expect(myfn).toHaveBeenCalledOnce()
+    })
+    test("Sleeps the input number of milliseconds", async () => {
+        const mockTimeout = vi.spyOn(global, 'setTimeout').mockImplementation((callback) => {callback(); return {hasRef: () => false} as NodeJS.Timeout})
+
+        const duration = 15
+        expect(mockTimeout).toHaveBeenCalledTimes(0)
+        await sleepMsec(duration)
+        expect(mockTimeout).toHaveBeenCalledOnce()
+        const observed = (mockTimeout.mock.lastCall ?? [0, 0])[1]
+        expect(observed).toEqual(duration)
+    })
+})

--- a/test/util/sortedListsAreEqual.test.ts
+++ b/test/util/sortedListsAreEqual.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import sortedListsAreEqual from '../../src/util/sortedListsAreEqual'
+
+describe("Sorted list comparison function", () => {
+    test("Returns false if list lengths differ", () => {
+        const l1 = [1, 2, 3, 4, 5]
+        const l2 = [1, 2, 3, 4]
+        expect(sortedListsAreEqual(l1, l2)).toBeFalsy()
+    })
+    test("Returns false if lists contain a differing item", () => {
+        const l1 = [1, 2, 3, 4, 5]
+        const l2 = [1, 2, 3, 4, 6]
+        expect(sortedListsAreEqual(l1, l2)).toBeFalsy()
+    })
+    test("Returns false if one list is unsorted", () => {
+        // Note: if this starts failing, congratulations! The code works better than before
+        const l1 = [1, 2, 3, 4, 5]
+        const l2 = [5, 4, 3, 2, 1]
+        expect(sortedListsAreEqual(l1, l2)).toBeFalsy()
+    })
+    test("Returns true if lists have the same items", () => {
+        const l1 = [1, 2, 3, 4, 5]
+        const l2 = [1, 2, 3, 4, 5]
+        expect(sortedListsAreEqual(l1, l2)).toBeTruthy()
+    })
+})


### PR DESCRIPTION
This PR presents a few changes to the gui-side webrtc networking code, mainly to facilitate testing.

The following were the significant changes:

- Move utility functions--sleeping, random alpha strings--out of [WebrtcConnectionToService.ts](https://github.com/flatironinstitute/mcmc-monitor/blob/main/src/networking/WebrtcConnectionToService.ts) into their own files.
- Implement [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) design pattern for the WebrtcConnectionToService so that it no longer instantiates its "pet" `SimplePeer` object in the constructor. This is mainly to allow testing, but could facilitate replacement in the future. It also necessitates breaking out some of the chained actions in configuring the `SimplePeer` object and attempting to connect, which had been part of the constructor.
- Replacing some of the internal-constant timeout values with named constants.
- Update `config.ts` to use the new instantiation procedure.

Now has 100% test coverage documenting the expected behaviors of the gui-side networking. I've also confirmed via dev run that it still works--console with local service documents communication over the webrtc channel. There may be proper integration tests to add that will check that as well; I've been focused on detailed unit testing.