### PR TITLE
Improve fallback to http

### DIFF
--- a/service/src/networking/RemotePeer.ts
+++ b/service/src/networking/RemotePeer.ts
@@ -18,6 +18,7 @@ const createPeer = async (connection: SignalCommunicatorConnection, outputMgr: O
     // wrtc is a conditional dependency (doesn't install on some versions of mac os). If it's not available, we can't use webrtc.
     let wrtc: any
     try {
+        // throw Error('Manually bypassing webrtc support')
         wrtc = await import('wrtc')
     }
     catch(err) {

--- a/service/src/networking/Server.ts
+++ b/service/src/networking/Server.ts
@@ -73,9 +73,7 @@ class Server {
                     console.warn('Unable to import wrtc')
                     canImportWrtc = false
                 }
-                // restore this line once we're configured to fall back to http while webrtc sets up
                 const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=${canImportWrtc ? "1" : "0"}`
-                // const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=0`
                 console.info('')
                 console.info(`Connect on remote machine: ${urlRemote}`)
                 console.info('')

--- a/service/src/networking/Server.ts
+++ b/service/src/networking/Server.ts
@@ -49,7 +49,9 @@ class Server {
         })
         const signalCommunicator = new SignalCommunicator()
         if (a.enableRemoteAccess) {
-            signalCommunicator.onConnection(async connection => {createPeer(connection, this.#outputManager, signalCommunicator)})
+            signalCommunicator.onConnection(async connection => {
+                createPeer(connection, this.#outputManager, signalCommunicator)
+            })
         }
         const urlLocal = `https://flatironinstitute.github.io/mcmc-monitor?s=http://localhost:${this.a.port}`
         console.info('')
@@ -72,8 +74,8 @@ class Server {
                     canImportWrtc = false
                 }
                 // restore this line once we're configured to fall back to http while webrtc sets up
-                // const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=${canImportWrtc ? "1" : "0"}`
-                const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=0`
+                const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=${canImportWrtc ? "1" : "0"}`
+                // const urlRemote = `https://flatironinstitute.github.io/mcmc-monitor?s=${proxyUrl}&webrtc=0`
                 console.info('')
                 console.info(`Connect on remote machine: ${urlRemote}`)
                 console.info('')

--- a/src/MCMCMonitorDataManager/MCMCMonitorDataTypes.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorDataTypes.ts
@@ -32,7 +32,6 @@ export type WebrtcConnectionStatus = 'unused' | 'pending' | 'connected' | 'error
 export type MCMCMonitorData = {
     connectedToService: boolean | undefined
     serviceProtocolVersion: string | undefined
-    webrtcConnectionStatus: WebrtcConnectionStatus
     usingProxy: boolean | undefined
     runs: MCMCRun[]
     chains: MCMCChain[]

--- a/src/MCMCMonitorDataManager/MCMCMonitorTypeguards.ts
+++ b/src/MCMCMonitorDataManager/MCMCMonitorTypeguards.ts
@@ -1,11 +1,6 @@
 import { isMCMCChain, isMCMCRun, isMCMCSequence } from '../../service/src/types'
 import validateObject, { isArrayOf, isBoolean, isNumber, isString, optional } from "../../service/src/types/validateObject"
-import { GeneralOpts, MCMCMonitorData, SequenceStats, SequenceStatsDict, VariableStats, VariableStatsDict, WebrtcConnectionStatus } from "./MCMCMonitorDataTypes"
-
-export const isWebrtcConnectionStatus = (x: any): x is WebrtcConnectionStatus => {
-    const validStatuses = ['unused', 'pending', 'connected', 'error']
-    return validStatuses.includes(x)
-}
+import { GeneralOpts, MCMCMonitorData, SequenceStats, SequenceStatsDict, VariableStats, VariableStatsDict } from "./MCMCMonitorDataTypes"
 
 export const isMCMCSequenceStats = (x: any): x is SequenceStats => {
     return validateObject(x, {
@@ -49,7 +44,6 @@ export const isMCMCMonitorData = (x: any): x is MCMCMonitorData => {
     return validateObject(x, {
         connectedToService: optional(isBoolean),
         serviceProtocolVersion: optional(isString),
-        webrtcConnectionStatus: isWebrtcConnectionStatus,
         usingProxy: optional(isBoolean),
         runs: isArrayOf(isMCMCRun),
         chains: isArrayOf(isMCMCChain),

--- a/src/MCMCMonitorDataManager/useMCMCMonitor.ts
+++ b/src/MCMCMonitorDataManager/useMCMCMonitor.ts
@@ -91,7 +91,6 @@ export const useMCMCMonitor = () => {
         selectedRunId: data.selectedRunId,
         connectedToService: data.connectedToService,
         serviceProtocolVersion: data.serviceProtocolVersion,
-        webrtcConnectionStatus: data.webrtcConnectionStatus,
         usingProxy: data.usingProxy,
         generalOpts: data.generalOpts,
         sequenceStats: data.sequenceStats,

--- a/src/components/ConnectionStatusWidget.tsx
+++ b/src/components/ConnectionStatusWidget.tsx
@@ -1,52 +1,52 @@
 import { FunctionComponent } from "react";
 import { useMCMCMonitor } from "../MCMCMonitorDataManager/useMCMCMonitor";
-import { serviceBaseUrl } from "../config";
+import { serviceBaseUrl, webrtcConnectionToService } from "../config";
 import Hyperlink from "./Hyperlink";
 
 type Props = any
 
 const ConnectionStatusWidget: FunctionComponent<Props> = () => {
-	const {usingProxy, connectedToService, webrtcConnectionStatus, checkConnectionStatus} = useMCMCMonitor()
+    const {usingProxy, connectedToService, checkConnectionStatus} = useMCMCMonitor()
 
-	const checkButton = (
-		<div><Hyperlink onClick={checkConnectionStatus}>Check connection status</Hyperlink></div>
-	)
+    const checkButton = (
+        <div><Hyperlink onClick={checkConnectionStatus}>Check connection status</Hyperlink></div>
+    )
 
-	if (!connectedToService) {
-		return (
-			<div>
-				<div style={{color: 'darkred'}}>Not connected to service: {serviceBaseUrl}</div>
+    if (!connectedToService) {
+        return (
+            <div>
+                <div style={{color: 'darkred'}}>Not connected to service: {serviceBaseUrl}</div>
                 {checkButton}
-			</div>
-		)
-	}
+            </div>
+        )
+    }
 
-	return (
-		<div>
-			<div style={{color: "darkgreen"}}>Connected to service: {serviceBaseUrl}</div>
+    return (
+        <div>
+            <div style={{color: "darkgreen"}}>Connected to service: {serviceBaseUrl}</div>
             <div>&nbsp;</div>
-			{
-				usingProxy ? (
-					<div>- Using proxy</div>
-				) : (
-					<div>- Not using proxy</div>
-				)
-			}
-			{
-				webrtcConnectionStatus === 'connected' ? (
-					<div>- Connected using WebRTC</div>
-				) : webrtcConnectionStatus === 'pending' ? (
-					<div>- WebRTC connection pending</div>
-				) : webrtcConnectionStatus === 'error' ? (
-					<div>- WebRTC connection error</div>
-				) : webrtcConnectionStatus === 'unused' ? (
-					<div>- Not using WebRTC</div>
-				) : <span />
-			}
+            {
+                usingProxy ? (
+                    <div>- Using proxy</div>
+                ) : (
+                    <div>- Not using proxy</div>
+                )
+            }
+            {
+                webrtcConnectionToService === undefined ? (
+                    <div>- Not using WebRTC</div>
+                ) : webrtcConnectionToService.status === 'pending' ? (
+                    <div>- WebRTC connection pending, using HTTP in the meantime</div>
+                ) : webrtcConnectionToService.status === 'error' ? (
+                    <div>- WebRTC connection error--using HTTP fallback</div>
+                ) : webrtcConnectionToService.status === 'connected' ? (
+                    <div>- Connected using WebRTC</div>
+                ) : <span />
+            }
             <div>&nbsp;</div>
             {checkButton}
-		</div>
-	)
+        </div>
+    )
 }
 
 export default ConnectionStatusWidget

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,8 +18,13 @@ export const useWebrtc = queryParams.webrtc === '1'
 
 export let webrtcConnectionToService: WebrtcConnectionToService | undefined
 
-if ((useWebrtc) && (!webrtcConnectionToService)) {
-    const peerInstance = new SimplePeer({initiator: true})
-    webrtcConnectionToService = new WebrtcConnectionToService(peerInstance).configurePeer()
-    webrtcConnectionToService?.connect()
-}
+setTimeout(() => {
+    // setting the timeout allows the import of postApiRequest to complete before it gets
+    // called in the connect() method.
+    // Otherwise, you get an (apparently ignorable, but annoying) error during connection setup.
+    if ((useWebrtc) && (!webrtcConnectionToService)) {
+        const peerInstance = new SimplePeer({initiator: true})
+        webrtcConnectionToService = new WebrtcConnectionToService(peerInstance).configurePeer()
+        webrtcConnectionToService?.connect()
+    }
+}, 0)

--- a/src/networking/WebrtcConnectionToService.ts
+++ b/src/networking/WebrtcConnectionToService.ts
@@ -101,7 +101,6 @@ class WebrtcConnectionToService {
     }
 }
 
-<<<<<<< HEAD
 export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instance, s: SimplePeer.SignalData | undefined) => {
     const request: WebrtcSignalingRequest = {
         type: 'webrtcSignalingRequest',
@@ -118,6 +117,4 @@ export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instan
     }
 }
 
-=======
->>>>>>> 3258797 (Separate utility functions. Outline tests for web rtc cnxn.)
 export default WebrtcConnectionToService

--- a/src/networking/WebrtcConnectionToService.ts
+++ b/src/networking/WebrtcConnectionToService.ts
@@ -101,6 +101,7 @@ class WebrtcConnectionToService {
     }
 }
 
+<<<<<<< HEAD
 export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instance, s: SimplePeer.SignalData | undefined) => {
     const request: WebrtcSignalingRequest = {
         type: 'webrtcSignalingRequest',
@@ -117,4 +118,6 @@ export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instan
     }
 }
 
+=======
+>>>>>>> 3258797 (Separate utility functions. Outline tests for web rtc cnxn.)
 export default WebrtcConnectionToService

--- a/src/networking/WebrtcConnectionToService.ts
+++ b/src/networking/WebrtcConnectionToService.ts
@@ -111,7 +111,6 @@ export const sendWebrtcSignal = async (clientId: string, peer: SimplePeer.Instan
         clientId,
         signal: s === undefined ? undefined : JSON.stringify(s)
     }
-    if (!postApiRequest) return
     const response = await postApiRequest(request)
     if (response.type !== 'webrtcSignalingResponse') {
         console.warn(response)

--- a/src/networking/postApiRequest.ts
+++ b/src/networking/postApiRequest.ts
@@ -4,7 +4,7 @@ import { serviceBaseUrl, useWebrtc, webrtcConnectionToService } from "../config"
 const postApiRequest = async (request: MCMCMonitorRequest): Promise<MCMCMonitorResponse> => {
     // Note: we always use http for probe requests and webrtc signaling requests
     if ((useWebrtc) && (request.type !== 'probeRequest') && (request.type !== 'webrtcSignalingRequest')) {
-        if (webrtcConnectionToService) {
+        if (webrtcConnectionToService && webrtcConnectionToService.status === 'connected') {
             // if we have a webrtc connection, post the request via webrtc
             return webrtcConnectionToService.postApiRequest(request)
         }

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -50,11 +50,11 @@ const MainWindow: FunctionComponent<Props> = (props: Props) => {
     }
 }
 
-const WebRtcError: FunctionComponent = () => {
-    return (
-        <div>Unable to connect to service using WebRTC: {serviceBaseUrl}</div>
-    )
-}
+// const WebRtcError: FunctionComponent = () => {
+//     return (
+//         <div>Unable to connect to service using WebRTC: {serviceBaseUrl}</div>
+//     )
+// }
 
 const ConnectionInProgress: FunctionComponent = () => {
     return (

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -50,12 +50,6 @@ const MainWindow: FunctionComponent<Props> = (props: Props) => {
     }
 }
 
-// const WebRtcError: FunctionComponent = () => {
-//     return (
-//         <div>Unable to connect to service using WebRTC: {serviceBaseUrl}</div>
-//     )
-// }
-
 const ConnectionInProgress: FunctionComponent = () => {
     return (
         <div>Connecting to service{useWebrtc ? ' using WebRTC' : ''}: {serviceBaseUrl}</div>

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -17,16 +17,10 @@ type Props = {
 const MainWindow: FunctionComponent<Props> = (props: Props) => {
     const { dataManager } = props
 	const { route } = useRoute()
-	const { updateRuns, serviceProtocolVersion } = useMCMCMonitor()
+	const { updateRuns, serviceProtocolVersion, connectedToService } = useMCMCMonitor()
 	useEffect(() => {
 		updateRuns()
 	}, [updateRuns])
-
-	const {connectedToService, webrtcConnectionStatus} = useMCMCMonitor()
-
-	if (webrtcConnectionStatus === 'error') {
-        return <WebRtcError />
-	}
 
 	if (connectedToService === undefined) {
         return <ConnectionInProgress />

--- a/test/MCMCMonitorDataManager/MCMCMonitorData.test.ts
+++ b/test/MCMCMonitorDataManager/MCMCMonitorData.test.ts
@@ -308,17 +308,6 @@ describe("MCMCMonitorData reducer connection accounting", () => {
         ceterisParibus(data, res, ["serviceProtocolVersion"])
         expect(res.serviceProtocolVersion).toBe(newProtocol)
     })
-    test("Setting Web RTC connection persists", () => {
-        const newStatus = "pending"
-        expect(data.webrtcConnectionStatus !== newStatus).toBeTruthy()
-        const action = {
-            type: "setWebrtcConnectionStatus",
-            status: newStatus
-        } as any as MCMCMonitorAction
-        const res = mcmcMonitorReducer(data, action)
-        ceterisParibus(data, res, ["webrtcConnectionStatus"])
-        expect(res.webrtcConnectionStatus).toBe(newStatus)
-    })
     test("Setting proxy status persists", () => {
         const newProxy = !data.usingProxy
         const action = {


### PR DESCRIPTION
Fix issue #66. Obviates (& undoes) #68.

(Git history is a little confusing--I had originally branched this off the branch from PR #78, so there's weirdness.)

There are two main barriers to seamless HTTP fallback:
1. Broadening the conditions of the `postApiRequest` function so that it falls back in a wider variety of cases.
1. Refactoring the connect-first busy-waiting during startup.

## Changes

### Incidental Changes:
- A couple temporary changes for testing the effect of the other changes (all changes in `service` tree).
- As part of broadening the criteria in `postApiRequest`, I've removed web RTC connection status from the `MCMCMonitorData` client-side cache. Instead, relevant components can simply access the singleton connection object (if it exists) directly. (Changes to files in `MCMCMonitorDataManager` directory, to corresponding tests, and in `components/ConnectionStatusWidget`)
- An earlier revision to the code resulted in an ultimately insignificant, but annoying, error being thrown during spin-up of webrtc connections, due to a circular import in the `src/config.ts` global configuration setter. This can be fixed by deferring the actual initiation of connection with a `setTimeout` call.
- Since we no longer ever cause a fatal error due to failed WebRTC connection, part of `MainWindow.tsx` was no longer relevant (the `WebRtcError` component).
- Updated `postApiRequest` tests to reflect and test current intended behavior.

### Major changes:
- Updating the fallback condition for `postApiRequest` is quite easy--that's the one-line change in `postApiRequest.ts`.
- Updating the connection-initiation process is a little bit more involved. That's the changes in `src/MCMCMonitorDataManager/SetupMCMCMonitor.tsx` and `src/networking/WebrtcConnectionToService.ts`.
  - In the former, I've removed the logic that tries to interpret the web rtc connection status.
  - In the latter, I've updated the connection loop. Previously we had a timer within the function and a hard loop that blocked while the status was `pending`. I've updated this to make the timer an instance variable (so it persists between calls to `connect()`) and have the connect function call itself on a timer. This allows other processing to proceed while the connection is being established. Any requests that come through during that lag time will see that the WebrtcConnection's status is not `connected` and fall through to HTTP.

## Testing

We haven't really begun automated integration testing, so I don't have anything automated to test this--though the updated unit tests give confidence that everything should still work. The more important test here was practical.

I checked this out in a couple ways, running both the GUI and service on my local machine:

- Confirm that non-proxy connections work. No webrtc expected; connection works fine.
- Use proxy link with `webrtc=0`; confirm that data transmits successfully, connection status shows using proxy without webrtc.
- Set `webrtc=1` in URL; confirm that data transmits successfully, connection status shows using proxy with webrtc.
- Keep `webrtc=1`. Uncomment the line in `service/src/networking/RemotePeer.ts` reading `throw Error('Manually bypassing webrtc support')` to simulate unconnectable remote service. Confirm that data is transmitted and connection status shows using proxy without webrtc. Recomment this line.
- Keep `webrtc=1`. Add a `setTimeout` call around l. 52-54 in `service/src/networking/Server.ts` (the call to `createPeer`) to impose a 5-second delay in initiating the connection. Confirmed that data can still be transferred to the GUI and that the connection status indicates a webRTC connection is pending, until it eventually times out and says the status is errored. In both cases, data is still transferring via HTTP.

**Potential concern:** I tested fake slowness, but was not able to hit the case where a connection is pending for a while, then eventually connects. I think this had to do with how I was imposing lag in the service. I am assuming that in an actual longer negotiation process it would eventually connect--after all, connecting clearly works fine--but we may want to find a better way to confirm this case before merging.

GUI changes deployed to dev branch and visible at https://flatironinstitute.github.io/mcmc-monitor/dev/ (though seeing anything interesting will require running and connecting to a local service).