### PR TITLE
support loading of stan playground runs

### DIFF
--- a/src/MCMCMonitorDataManager/updateSequences.ts
+++ b/src/MCMCMonitorDataManager/updateSequences.ts
@@ -1,25 +1,39 @@
-import { GetSequencesRequest, isGetSequencesResponse } from "../../service/src/types";
+import { GetSequencesRequest, isGetSequencesResponse, MCMCSequenceUpdate } from "../../service/src/types";
 import postApiRequest from "../networking/postApiRequest";
+import getSpaSequenceUpdates from "../spaInterface/getSpaSequenceUpdates";
 import { MCMCMonitorAction, MCMCMonitorData } from "./MCMCMonitorDataTypes";
-
 
 export default async function updateSequences(data: MCMCMonitorData, dispatch: (a: MCMCMonitorAction) => void) {
     const X = data.sequences.filter(s => (s.updateRequested))
     if (X.length > 0) {
-        const req: GetSequencesRequest = {
-            type: 'getSequencesRequest',
-            sequences: X.map(s => ({
-                runId: s.runId, chainId: s.chainId, variableName: s.variableName, position: s.data.length
-            }))
+        const runId = X[0].runId
+        if (runId.startsWith('spa|')) {
+            // handle the special case of a stan playground run
+            const sequenceUpdates: MCMCSequenceUpdate[] | undefined = await getSpaSequenceUpdates(runId, X)
+            if (sequenceUpdates) {
+                dispatch({
+                    type: "updateSequenceData",
+                    sequences: sequenceUpdates
+                })
+            }
         }
-        const resp = await postApiRequest(req)
-        if (!isGetSequencesResponse(resp)) {
-            console.warn(resp)
-            throw Error('Unexpected getSequences response')
+        else {
+            // handle the usual case
+            const req: GetSequencesRequest = {
+                type: 'getSequencesRequest',
+                sequences: X.map(s => ({
+                    runId: s.runId, chainId: s.chainId, variableName: s.variableName, position: s.data.length
+                }))
+            }
+            const resp = await postApiRequest(req)
+            if (!isGetSequencesResponse(resp)) {
+                console.warn(resp)
+                throw Error('Unexpected getSequences response')
+            }
+            dispatch({
+                type: "updateSequenceData",
+                sequences: resp.sequences
+            })
         }
-        dispatch({
-            type: "updateSequenceData",
-            sequences: resp.sequences
-        })
     }
 }

--- a/src/MCMCMonitorDataManager/useMCMCMonitor.ts
+++ b/src/MCMCMonitorDataManager/useMCMCMonitor.ts
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useMemo } from 'react'
 import { GetChainsForRunRequest, GetRunsRequest, MCMCChain, MCMCRun, isGetChainsForRunResponse, isGetRunsResponse } from '../../service/src/types'
+import { serviceBaseUrl } from '../config'
 import postApiRequest from '../networking/postApiRequest'
 import getSpaChainsForRun from '../spaInterface/getSpaChainsForRun'
 import { MCMCMonitorContext, detectedWarmupIterationCount } from './MCMCMonitorData'
@@ -33,6 +34,7 @@ export const useMCMCMonitor = () => {
 
     const updateRuns = useCallback(() => {
         ; (async () => {
+            if (!serviceBaseUrl) return // for example, spa mode
             const req: GetRunsRequest = {
                 type: 'getRunsRequest'
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,15 @@ export const defaultServiceBaseUrl = 'http://localhost:61542'
 
 export const exampleServiceBaseUrl = 'https://lit-bayou-76056.herokuapp.com'
 
+export const spaMode = queryParams.s === 'spa'
+
 export const serviceBaseUrl = queryParams.s ? (
-    queryParams.s === 'spa' ? '' : queryParams.s // if we are in spa mode, don't use a serviceBaseUrl
+    spaMode ? '' : queryParams.s // if we are in spa mode, don't use a serviceBaseUrl
 ) : (
     defaultServiceBaseUrl
 )
+
+export const stanPlaygroundUrl = "https://stan-playground.vercel.app/api/playground"
 
 export const useWebrtc = queryParams.webrtc === '1'
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export const defaultServiceBaseUrl = 'http://localhost:61542'
 export const exampleServiceBaseUrl = 'https://lit-bayou-76056.herokuapp.com'
 
 export const serviceBaseUrl = queryParams.s ? (
-    queryParams.s
+    queryParams.s === 'spa' ? '' : queryParams.s // if we are in spa mode, don't use a serviceBaseUrl
 ) : (
     defaultServiceBaseUrl
 )

--- a/src/networking/postApiRequest.ts
+++ b/src/networking/postApiRequest.ts
@@ -2,6 +2,7 @@ import { MCMCMonitorRequest, MCMCMonitorResponse, isMCMCMonitorResponse } from "
 import { serviceBaseUrl, useWebrtc, webrtcConnectionToService } from "../config"
 
 const postApiRequest = async (request: MCMCMonitorRequest): Promise<MCMCMonitorResponse> => {
+    if (!serviceBaseUrl) throw Error('serviceBaseUrl not set') // for example, if we are in spa mode
     // Note: we always use http for probe requests and webrtc signaling requests
     if ((useWebrtc) && (request.type !== 'probeRequest') && (request.type !== 'webrtcSignalingRequest')) {
         if (webrtcConnectionToService && webrtcConnectionToService.status === 'connected') {

--- a/src/networking/postApiRequest.ts
+++ b/src/networking/postApiRequest.ts
@@ -1,8 +1,9 @@
 import { MCMCMonitorRequest, MCMCMonitorResponse, isMCMCMonitorResponse } from "../../service/src/types"
-import { serviceBaseUrl, useWebrtc, webrtcConnectionToService } from "../config"
+import { serviceBaseUrl, spaMode, useWebrtc, webrtcConnectionToService } from "../config"
 
 const postApiRequest = async (request: MCMCMonitorRequest): Promise<MCMCMonitorResponse> => {
-    if (!serviceBaseUrl) throw Error('serviceBaseUrl not set') // for example, if we are in spa mode
+    if (spaMode) throw Error('Unexpected: cannot postApiRequest in spa mode')
+    if (!serviceBaseUrl) throw Error('Unexpected in postApiRequest: serviceBaseUrl not set')
     // Note: we always use http for probe requests and webrtc signaling requests
     if ((useWebrtc) && (request.type !== 'probeRequest') && (request.type !== 'webrtcSignalingRequest')) {
         if (webrtcConnectionToService && webrtcConnectionToService.status === 'connected') {

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -22,17 +22,19 @@ const MainWindow: FunctionComponent<Props> = (props: Props) => {
 		updateRuns()
 	}, [updateRuns])
 
-	if (connectedToService === undefined) {
-        return <ConnectionInProgress />
-	}
+    if (serviceBaseUrl) {
+        if (connectedToService === undefined) {
+            return <ConnectionInProgress />
+        }
 
-	if (connectedToService === false) {
-		return (
-            <LogoFrame>
-                <FailedConnection serviceProtocolVersion={serviceProtocolVersion} />
-            </LogoFrame>
-		)
-	}
+        if (connectedToService === false) {
+            return (
+                <LogoFrame>
+                    <FailedConnection serviceProtocolVersion={serviceProtocolVersion} />
+                </LogoFrame>
+            )
+        }
+    }
 
     switch (route.page) {
         case "home":

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -8,6 +8,7 @@ import useRoute from "../util/useRoute";
 import Home from "./Home";
 import Logo from "./Logo";
 import RunPage from "./RunPage";
+import { constructSpaRunId } from "../spaInterface/util";
 
 
 type Props = {
@@ -48,7 +49,7 @@ const MainWindow: FunctionComponent<Props> = (props: Props) => {
             return <RunPage runId={route.runId} dataManager={dataManager} />
             break
         case "spa":
-            return <RunPage runId={`spa|${route.analysisId}|${route.fileName}`} dataManager={dataManager} />
+            return <RunPage runId={constructSpaRunId(route.projectId, route.fileName)} dataManager={dataManager} />
         default:
             return <span />
     }

--- a/src/pages/MainWindow.tsx
+++ b/src/pages/MainWindow.tsx
@@ -45,6 +45,8 @@ const MainWindow: FunctionComponent<Props> = (props: Props) => {
         case "run":
             return <RunPage runId={route.runId} dataManager={dataManager} />
             break
+        case "spa":
+            return <RunPage runId={`spa|${route.analysisId}|${route.fileName}`} dataManager={dataManager} />
         default:
             return <span />
     }

--- a/src/pages/RunPage.tsx
+++ b/src/pages/RunPage.tsx
@@ -53,9 +53,6 @@ const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
 		return Math.max(...a)
 	}, [sequences, runId])
 
-	// not actually used
-	// const run: MCMCRun | undefined = useMemo(() => (runs.filter(r => (r.runId === runId))[0]), [runs, runId])
-
 	const chainsForRun = useMemo(() => {
         return (chains.filter(c => (c.runId === runId))
                       .sort((a, b) => a.chainId.localeCompare(b.chainId)))
@@ -79,8 +76,6 @@ const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
 
 	const {width, height} = useWindowDimensions()
 
-	// this check is unnecessary
-	// if (!run) return <span>Run not found: {runId}</span>
 	return (
 		<div style={{position: 'absolute', width: width - 40, height: height - 40, margin: 20, overflow: 'hidden'}}>
 			<Splitter

--- a/src/pages/RunPage.tsx
+++ b/src/pages/RunPage.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useEffect, useMemo } from "react";
-import { MCMCChain, MCMCRun } from "../../service/src/types";
+import { MCMCChain } from "../../service/src/types";
 import MCMCDataManager from "../MCMCMonitorDataManager/MCMCMonitorDataManager";
 import { useMCMCMonitor } from "../MCMCMonitorDataManager/useMCMCMonitor";
 import RunControlPanel from "../components/RunControlPanel";
@@ -14,7 +14,7 @@ type Props = {
 }
 
 const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
-	const {runs, chains, sequences, updateChainsForRun, setSelectedChainIds, generalOpts, updateKnownData, setSelectedRunId} = useMCMCMonitor()
+	const {chains, sequences, updateChainsForRun, setSelectedChainIds, generalOpts, updateKnownData, setSelectedRunId} = useMCMCMonitor()
 
     useEffect(() => {
         if (dataManager === undefined) return
@@ -53,7 +53,8 @@ const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
 		return Math.max(...a)
 	}, [sequences, runId])
 
-	const run: MCMCRun | undefined = useMemo(() => (runs.filter(r => (r.runId === runId))[0]), [runs, runId])
+	// not actually used
+	// const run: MCMCRun | undefined = useMemo(() => (runs.filter(r => (r.runId === runId))[0]), [runs, runId])
 
 	const chainsForRun = useMemo(() => {
         return (chains.filter(c => (c.runId === runId))
@@ -78,7 +79,8 @@ const RunPage: FunctionComponent<Props> = ({runId, dataManager}) => {
 
 	const {width, height} = useWindowDimensions()
 
-	if (!run) return <span>Run not found: {runId}</span>
+	// this check is unnecessary
+	// if (!run) return <span>Run not found: {runId}</span>
 	return (
 		<div style={{position: 'absolute', width: width - 40, height: height - 40, margin: 20, overflow: 'hidden'}}>
 			<Splitter

--- a/src/spaInterface/getSpaChainsForRun.ts
+++ b/src/spaInterface/getSpaChainsForRun.ts
@@ -1,0 +1,27 @@
+import { MCMCChain } from "../../service/src/types";
+import { spaOutputsForRunIds, updateSpaOutputForRun } from "./spaOutputsForRunIds";
+
+const getSpaChainsForRun = async (runId: string): Promise<MCMCChain[]> => {
+    await updateSpaOutputForRun(runId)
+    const cachedEntry = spaOutputsForRunIds[runId]
+    if (!cachedEntry) {
+        console.warn('Unable to load data for run', runId)
+        return []
+    }
+    const spaOutput = cachedEntry.spaOutput
+    const ret: MCMCChain[] = []
+    for (const ch of spaOutput.chains) {
+        ret.push({
+            runId,
+            chainId: ch.chainId,
+            variableNames: Object.keys(ch.sequences),
+            rawHeader: ch.rawHeader,
+            rawFooter: ch.rawFooter,
+            lastChangeTimestamp: Date.now(),
+            excludedInitialIterationCount: ch.numWarmupDraws ?? 0,
+        })
+    }
+    return ret
+}
+
+export default getSpaChainsForRun

--- a/src/spaInterface/getSpaSequenceUpdates.ts
+++ b/src/spaInterface/getSpaSequenceUpdates.ts
@@ -1,0 +1,27 @@
+import { MCMCSequence, MCMCSequenceUpdate } from "../../service/src/types";
+import { spaOutputsForRunIds, updateSpaOutputForRun } from "./spaOutputsForRunIds";
+
+const getSpaSequenceUpdates = async (runId: string, sequences: MCMCSequence[]): Promise<MCMCSequenceUpdate[] | undefined> => {
+    await updateSpaOutputForRun(runId)
+    const cachedEntry = spaOutputsForRunIds[runId]
+    if (!cachedEntry) {
+        console.warn('Unable to load data for run', runId)
+        return []
+    }
+    const spaOutput = cachedEntry.spaOutput
+    
+    const ret: MCMCSequenceUpdate[] = []
+    for (const seq of sequences) {
+        const data = spaOutput.chains.find(c => c.chainId === seq.chainId)?.sequences[seq.variableName] ?? []
+        ret.push({
+            runId,
+            chainId: seq.chainId,
+            variableName: seq.variableName,
+            position: seq.data.length,
+            data: data.slice(seq.data.length)
+        })
+    }
+    return ret
+}
+
+export default getSpaSequenceUpdates

--- a/src/spaInterface/postStanPlaygroundRequest.ts
+++ b/src/spaInterface/postStanPlaygroundRequest.ts
@@ -1,0 +1,19 @@
+const postStanPlaygroundRequest = async (req: any): Promise<any> => {
+    const url = `https://stan-playground.vercel.app/api/playground`
+    // const url = `http://localhost:3000/api/playground`
+
+    const rr = {
+        payload: req
+    }
+    const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(rr),
+    })
+    const responseData = await resp.json()
+    return responseData
+}
+
+export default postStanPlaygroundRequest

--- a/src/spaInterface/postStanPlaygroundRequest.ts
+++ b/src/spaInterface/postStanPlaygroundRequest.ts
@@ -1,6 +1,7 @@
+import { stanPlaygroundUrl } from "../config"
+
 const postStanPlaygroundRequest = async (req: any): Promise<any> => {
-    const url = `https://stan-playground.vercel.app/api/playground`
-    // const url = `http://localhost:3000/api/playground`
+    const url = stanPlaygroundUrl
 
     const rr = {
         payload: req

--- a/src/spaInterface/spaOutputsForRunIds.ts
+++ b/src/spaInterface/spaOutputsForRunIds.ts
@@ -1,0 +1,63 @@
+import postStanPlaygroundRequest from "./postStanPlaygroundRequest";
+
+export type SpaOutput = {
+    chains: {
+        chainId: string,
+        rawHeader: string,
+        rawFooter: string,
+        numWarmupDraws?: number,
+        sequences: {
+            [key: string]: number[]
+        }
+    }[]
+}
+
+export const spaOutputsForRunIds: {[key: string]: {
+    sha1: string,
+    spaOutput: SpaOutput
+}} = {}
+
+export const updateSpaOutputForRun = async (runId: string) => {
+    const a = runId.split('|')
+        const projectId = a[1]
+        const fileName = a[2]
+    
+    // first we need to get the sha1 of the latest file
+    const req = {
+        type: 'getProjectFile',
+        timestamp: Date.now() / 1000,
+        projectId,
+        fileName
+    }
+    const resp = await postStanPlaygroundRequest(req)
+    if (resp.type !== 'getProjectFile') {
+        console.warn(resp)
+        throw Error('Unexpected response from Stan Playground')
+    }
+    const sha1 = resp.projectFile.contentSha1
+
+    const cachedEntry = spaOutputsForRunIds[runId]
+    if ((cachedEntry && cachedEntry.sha1 === sha1)) {
+        // we already have the latest version
+        return
+    }
+
+    const req2 = {
+        type: 'getDataBlob',
+        timestamp: Date.now() / 1000,
+        workspaceId: resp.projectFile.workspaceId,
+        projectId,
+        sha1
+    }
+    const resp2 = await postStanPlaygroundRequest(req2)
+    if (resp2.type !== 'getDataBlob') {
+        console.warn(resp2)
+        throw Error('Unexpected response from Stan Playground')
+    }
+    const x = JSON.parse(resp2.content)
+    const spaOutput = x as SpaOutput
+    spaOutputsForRunIds[runId] = {
+        sha1,
+        spaOutput
+    }
+}

--- a/src/spaInterface/spaOutputsForRunIds.ts
+++ b/src/spaInterface/spaOutputsForRunIds.ts
@@ -1,4 +1,5 @@
 import postStanPlaygroundRequest from "./postStanPlaygroundRequest";
+import { parseSpaRunId } from "./util";
 
 export type SpaOutput = {
     chains: {
@@ -18,9 +19,7 @@ export const spaOutputsForRunIds: {[key: string]: {
 }} = {}
 
 export const updateSpaOutputForRun = async (runId: string) => {
-    const a = runId.split('|')
-        const projectId = a[1]
-        const fileName = a[2]
+    const {projectId, fileName} = parseSpaRunId(runId)
     
     // first we need to get the sha1 of the latest file
     const req = {

--- a/src/spaInterface/util.ts
+++ b/src/spaInterface/util.ts
@@ -1,0 +1,19 @@
+export const isSpaRunId = (runId: string): boolean => {
+    return runId.startsWith('spa|')
+}
+
+export const constructSpaRunId = (projectId: string, fileName: string): string => {
+    return `spa|${projectId}|${fileName}`
+}
+
+export const parseSpaRunId = (runId: string): {projectId: string, fileName: string} => {
+    const a = runId.split('|')
+    if (a.length !== 3) throw Error(`Invalid SPA runId: ${runId}`)
+    if (a[0] !== 'spa') throw Error(`Invalid SPA runId: ${runId}`)
+    const projectId = a[1]
+    const fileName = a[2]
+    return {
+        projectId,
+        fileName
+    }
+}

--- a/src/util/useRoute.ts
+++ b/src/util/useRoute.ts
@@ -8,7 +8,7 @@ export type Route = {
     runId: string
 } | {
     page: 'spa',
-    analysisId: string
+    projectId: string
     fileName: string
 }
 
@@ -27,11 +27,11 @@ const useRoute = () => {
         }
         else if (location.pathname.startsWith('/spa/')) {
             const a = location.pathname.split('/')
-            const analysisId = a[2]
+            const projectId = a[2]
             const fileName = a[3]
             return {
                 page: 'spa',
-                analysisId,
+                projectId,
                 fileName
             }
         }
@@ -50,7 +50,7 @@ const useRoute = () => {
             navigate({...location, pathname: `/run/${r.runId}`})
         }
         else if (r.page === 'spa') {
-            navigate({...location, pathname: `/spa/${r.analysisId}/${r.fileName}`})
+            navigate({...location, pathname: `/spa/${r.projectId}/${r.fileName}`})
         }
     }, [location, navigate])
 

--- a/src/util/useRoute.ts
+++ b/src/util/useRoute.ts
@@ -6,6 +6,10 @@ export type Route = {
 } | {
     page: 'run',
     runId: string
+} | {
+    page: 'spa',
+    analysisId: string
+    fileName: string
 }
 
 const useRoute = () => {
@@ -21,6 +25,16 @@ const useRoute = () => {
                 runId
             }
         }
+        else if (location.pathname.startsWith('/spa/')) {
+            const a = location.pathname.split('/')
+            const analysisId = a[2]
+            const fileName = a[3]
+            return {
+                page: 'spa',
+                analysisId,
+                fileName
+            }
+        }
         else {
             return {
                 page: 'home'
@@ -34,6 +48,9 @@ const useRoute = () => {
         }
         else if (r.page === 'run') {
             navigate({...location, pathname: `/run/${r.runId}`})
+        }
+        else if (r.page === 'spa') {
+            navigate({...location, pathname: `/spa/${r.analysisId}/${r.fileName}`})
         }
     }, [location, navigate])
 

--- a/test/MCMCMonitorDataManager/updateSequences.test.ts
+++ b/test/MCMCMonitorDataManager/updateSequences.test.ts
@@ -4,6 +4,7 @@ import { MCMCMonitorAction, MCMCMonitorData } from '../../src/MCMCMonitorDataMan
 
 type apiEndpoint = (request: MCMCMonitorRequest) => Promise<MCMCMonitorResponse>
 type dispatcher = (a: MCMCMonitorAction) => void
+type spaSequenceUpdates = (runId: string, sequences: MCMCSequence[]) => Promise<MCMCSequenceUpdate[] | undefined>
 
 type mockSequence = {
     runId: string,
@@ -52,6 +53,7 @@ describe("Sequence update request function", () => {
     let mockDispatch: dispatcher
     let mockData: MCMCMonitorData
     let mockResponse: GetSequencesResponse
+    let mockGetSpaSequenceUpdates: Mock
     
     beforeEach(() => {
         mockDispatchBase = vi.fn()
@@ -69,6 +71,14 @@ describe("Sequence update request function", () => {
             return {
                 __esModule: true,
                 default: mockPostApiRequestFn as unknown as apiEndpoint
+            }
+        })
+
+        mockGetSpaSequenceUpdates = vi.fn()
+        vi.doMock('../../src/spaInterface/getSpaSequenceUpdates', () => {
+            return {
+                __esModule: true,
+                default: mockGetSpaSequenceUpdates as unknown as spaSequenceUpdates
             }
         })
     })

--- a/test/networking/postApiRequest.test.ts
+++ b/test/networking/postApiRequest.test.ts
@@ -54,6 +54,7 @@ describe("Post API Request function", () => {
             return {
                 __esModule: true,
                 serviceBaseUrl: myBaseUrl,
+                spaMode: false,
                 useWebrtc,
                 webrtcConnectionToService: rtcCnxn
             }
@@ -86,6 +87,7 @@ describe("Post API Request function", () => {
             return {
                 __esModule: true,
                 serviceBaseUrl: myBaseUrl,
+                spaMode: false,
                 useWebrtc: true,
                 webrtcConnectionToService: rtcCnxn
             }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
         reporter: ['text', 'lcov']
     },
     exclude: [...configDefaults.exclude, "service/**"],
-    environment: 'jsdom'
   },
   plugins: [
     react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
         provider: "c8",
         reporter: ['text', 'lcov']
     },
-    exclude: [...configDefaults.exclude, "service/**"]
+    exclude: [...configDefaults.exclude, "service/**"],
+    environment: 'jsdom'
   },
   plugins: [
     react(),


### PR DESCRIPTION
For example:

http://localhost:5173/mcmc-monitor?s=spa#/spa/vzundlxu/main.spa.out
when merged and deployed this will become
https://flatironinstitute.github.io/mcmc-monitor?s=spa#/spa/vzundlxu/main.spa.out

Here `s=spa` means that we are not connecting to a service, but rather we are going to retrieve the data from the stan playground database (spa stands for stan playground analysis)

The `/spa/vzundlxu/main.spa.out` path is referring to a particular project ID and output file name.

I tried to interfere as little as possible with the existing flow. The main new stuff is in the src/spaInterface folder. That has logic to query the serverless API of stan playground (on vercel).

Internally, the runId takes the form `spa|{projectId}|{fileName}` and then in a couple of places we detect that format and then retrieve data using the alternative mechanism. The state management (dispatch, etc) is not changed.