### PR TITLE
Test tab widget

### DIFF
--- a/src/tabs/TabWidget/TabWidget.tsx
+++ b/src/tabs/TabWidget/TabWidget.tsx
@@ -16,14 +16,21 @@ const tabBarHeight = 30 + 25
 const TabWidget: FunctionComponent<PropsWithChildren<Props>> = ({children, tabs, width, height}) => {
     const [currentTabIndex, setCurrentTabIndex] = useState<number>(0)
 
-    const tabViews = useMemo(() => Array.isArray(children) ? (children as React.ReactElement[]) : ([children] as React.ReactElement[]), [children])
-    if ((tabViews || []).length !== tabs.length) {
-        throw Error(`TabWidget: incorrect number of tabs ${(tabViews || []).length} <> ${tabs.length}`)
+    const tabViews = useMemo(() => (Array.isArray(children) ? (children) : ([children])), [children]) as React.ReactElement[]
+    if (tabViews.length !== tabs.length) {
+        throw Error(`TabWidget: incorrect number of tabs ${tabViews.length} <> ${tabs.length}`)
+    }
+    if (tabViews.some(v => v == null)) {
+        // Double-equals catches both null and undefined in this context.
+        // This probably can't happen--I've only seen a null in tabViews when there aren't actually any children.
+        // And even then it'd probably get caught by the length comparison. But just in case:
+        throw Error("TabWidget: null or undefined children detected")
     }
 
     const hMargin = 8
     const vMargin = 8
-    const W = (width || 300) - hMargin * 2
+    // const W = (width || 300) - hMargin * 2
+    const W = width - hMargin * 2
     const H = height - vMargin * 2
 
     // TODO: attach this styling into a class rather than hard-coding?
@@ -41,9 +48,6 @@ const TabWidget: FunctionComponent<PropsWithChildren<Props>> = ({children, tabs,
         }),
         [tabViews, H, W]
     )
-    if ((tabViews || []).length === 0) {
-        return <div />
-    }
 
     return (
         <div

--- a/src/tabs/TabWidget/TabWidgetTabBar.tsx
+++ b/src/tabs/TabWidget/TabWidgetTabBar.tsx
@@ -6,7 +6,7 @@ type Props = {
         label: string
         closeable: boolean
     }[]
-    currentTabIndex: number | undefined
+    currentTabIndex: number
     onCurrentTabIndexChanged: (i: number) => void
 }
 
@@ -14,7 +14,7 @@ const TabWidgetTabBar: FunctionComponent<Props> = ({ tabs, currentTabIndex, onCu
     const classes = ['ViewContainerTabBar']
     return (
         <Tabs
-            value={currentTabIndex || 0}
+            value={currentTabIndex}
             scrollButtons="auto"
             variant="scrollable"
             className={classes.join(' ')}

--- a/src/tabs/TabWidget/TabWidgetTabBar.tsx
+++ b/src/tabs/TabWidget/TabWidgetTabBar.tsx
@@ -1,5 +1,5 @@
 import { Tab, Tabs } from '@mui/material';
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent } from 'react';
 
 type Props = {
     tabs: {
@@ -11,13 +11,6 @@ type Props = {
 }
 
 const TabWidgetTabBar: FunctionComponent<Props> = ({ tabs, currentTabIndex, onCurrentTabIndexChanged }) => {
-    useEffect(() => {
-        if (currentTabIndex === undefined) {
-            if (tabs.length > 0) {
-                onCurrentTabIndexChanged(0)
-            }
-        }
-    }, [currentTabIndex, onCurrentTabIndexChanged, tabs.length])
     const classes = ['ViewContainerTabBar']
     return (
         <Tabs

--- a/test/components/TabWidget/TabWidget.test.tsx
+++ b/test/components/TabWidget/TabWidget.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+// import { Mock, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import matchers from '@testing-library/jest-dom/matchers'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React, { FunctionComponent } from 'react'
+import TabWidget from '../../../src/tabs/TabWidget/TabWidget'
+
+expect.extend(matchers)
+
+const myTabs = [
+    { label: "tab1", closeable: false },
+    { label: "tab2", closeable: true },
+    { label: "tab3", closeable: false }
+]
+
+const ChildA: FunctionComponent<{msg: string}> = (props: {msg: string}) => {
+    return (
+        <div>
+            <span>Child A</span>
+            {props.msg}
+        </div>
+    )
+}
+
+const ChildB: FunctionComponent<{msg: string}> = (props: {msg: string}) => {
+    return (
+        <div>
+            <span>Child B</span>
+            {props.msg}
+        </div>
+    )
+}
+
+const myChildren = [
+    <ChildA key="foo" msg={"hello world"} />,
+    <ChildB key="bar" msg={"goodbye"} />,
+    <ChildA key="baz" msg={"in a bottle"} />
+]
+
+describe("Tab widget", () =>{
+    afterEach(() => {
+        cleanup()
+    })
+
+    beforeEach(() => {
+
+    })
+
+    test("Throws when child count exceeds tab count", () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        expect(() => {
+            render(<TabWidget tabs={[myTabs[0]]} width={300} height={300}>
+                {...myChildren}
+            </TabWidget>)
+        }).toThrow(/incorrect number of tabs/)
+        vi.spyOn(console, 'error').mockRestore()
+    })
+
+    test("Throws when tab count exceeds child count", () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        expect(() => {
+            render(<TabWidget tabs={myTabs} width={300} height={300}>
+                {myChildren[0]}
+            </TabWidget>)
+        }).toThrow(/incorrect number of tabs/)
+        vi.spyOn(console, 'error').mockRestore()
+    })
+
+    test("Throws error on no children", () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {})
+        expect(() => render(<TabWidget tabs={[myTabs[0]]} width={300} height={300} />)).toThrow(/null or undefined children/)
+        vi.spyOn(console, 'error').mockRestore()
+    })
+
+    test("Renders children per their types", () => {
+        render(<TabWidget tabs={myTabs} width={300} height={300}>
+            {...myChildren}
+        </TabWidget>)
+        const rendered = screen.queryByText(/Child A/)
+        expect(rendered).toBeTruthy()
+    })
+
+    test("Renders new child when tab index changes", async () => {
+        render(<TabWidget tabs={myTabs} width={300} height={300}>
+            {...myChildren}
+        </TabWidget>)
+        const rendered = screen.queryByText(/Child A/)
+        expect(rendered).toBeTruthy()
+        const tab2Button = screen.getByText("tab2")
+        await userEvent.click(tab2Button)
+        const newRendered = screen.queryByText(/Child B/)
+        expect(newRendered).toBeTruthy()
+    })
+})

--- a/test/components/TabWidget/TabWidget.test.tsx
+++ b/test/components/TabWidget/TabWidget.test.tsx
@@ -1,12 +1,10 @@
 // @vitest-environment jsdom
 
-// import { Mock, afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-
 import matchers from '@testing-library/jest-dom/matchers'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { FunctionComponent } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import TabWidget from '../../../src/tabs/TabWidget/TabWidget'
 
 expect.extend(matchers)

--- a/test/components/TabWidget/TabWidgetTabBar.test.tsx
+++ b/test/components/TabWidget/TabWidgetTabBar.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+
+import matchers from '@testing-library/jest-dom/matchers'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import TabWidgetTabBar from '../../../src/tabs/TabWidget/TabWidgetTabBar'
+
+expect.extend(matchers)
+
+describe("Tab Bar component", () => {
+    // Note, the "closeable" property doesn't seem to have any behavior implemented for it currently here
+    // May have been deleted in the code getting ported over
+    const myTabs = [
+        { label: "tab0", closeable: false },
+        { label: "tab1", closeable: true },
+        { label: "tab2", closeable: false }
+    ]
+
+    afterEach(() => cleanup())
+
+    beforeEach(() => {
+        vi.resetModules()
+    })
+
+    test("Renders input tabs with correct current tab selected", () => {
+        render(<TabWidgetTabBar tabs={myTabs} currentTabIndex={0} onCurrentTabIndexChanged={() => {}} />)
+        const tabs = screen.queryAllByRole("tab")
+        expect(tabs.length).toBe(3)
+        expect(tabs[0].getAttribute("aria-selected")).toBe("true")
+        const unselected = tabs.filter(b => b.getAttribute("aria-selected") === 'false')
+        expect(unselected.length).toBe(2)
+    })
+    
+    test("Calls callback when tab changes", async () => {
+        const mockCallback = vi.fn()
+        render(<TabWidgetTabBar tabs={myTabs} currentTabIndex={1} onCurrentTabIndexChanged={mockCallback} />)
+        const selectedTab = screen.getByText("tab1")
+        expect(selectedTab.getAttribute("aria-selected")).toBe("true")
+        await userEvent.click(selectedTab)  // no change, so shouldn't trigger event
+        expect(mockCallback).toHaveBeenCalledTimes(0)
+        const lastTab = screen.getByText("tab2")
+        expect(lastTab.getAttribute("aria-selected")).toBe("false")
+        await userEvent.click(lastTab)
+        expect(mockCallback).toHaveBeenCalledOnce()
+        expect(mockCallback.mock.lastCall[0]).toBe(2)
+    })
+})


### PR DESCRIPTION
Adds some tests for the public behaviors of the `TabWidget` and `TabWidgetTabBar`.

I did some reorganizing of the `TabWidget` class to remove some logic that supported a commented-out feature, and to implement memoization for the displayed pane. I'm not sure if this would have performance implications due to eager rendering of some panes--so we might want to think about that a bit.

I also just set the `currentTabIndex` to be non-nullable with a default of 0, since the prior implementation appears to set it to 0 through a hook if it does happen to be undefined.