### PR TITLE
Update tab names per issue #87.

### DIFF
--- a/src/pages/RunPage.tsx
+++ b/src/pages/RunPage.tsx
@@ -4,7 +4,7 @@ import MCMCDataManager from "../MCMCMonitorDataManager/MCMCMonitorDataManager";
 import { useMCMCMonitor } from "../MCMCMonitorDataManager/useMCMCMonitor";
 import RunControlPanel from "../components/RunControlPanel";
 import Splitter from "../components/Splitter";
-import { AutoCorrelationTab, ConnectionTab, ExportTab, HistogramTab, RunInfoTab, ScatterplotsTab, TabWidget, TablesTab, TimeSeries } from "../tabs";
+import { AutoCorrelationTab, ConnectionTab, ExportTab, HistogramTab, RunInfoTab, ScatterplotsTab, SummaryStatsTab, TabWidget, TracePlotsTab } from "../tabs";
 import { chainColorForIndex } from "../util/chainColorList";
 import useWindowDimensions from "../util/useWindowDimensions";
 
@@ -108,8 +108,8 @@ type RightContentProps = {
 }
 
 const tabs = [
-	{label: 'Time Series', closeable: false},
-	{label: 'Tables', closeable: false},
+	{label: 'Trace Plots', closeable: false},
+	{label: 'Summary Statistics', closeable: false},
     {label: 'Autocorrelations', closeable: false},
     {label: 'Histograms', closeable: false},
 	{label: 'Run Info', closeable: false},
@@ -127,14 +127,14 @@ const RightContent: FunctionComponent<RightContentProps> = ({width, height, numD
 			width={width}
 			height={height}
 		>
-			<TimeSeries
+			<TracePlotsTab
 				width={0}
 				height={0}
 				runId={runId}
 				chainColors={chainColors}
 				numDrawsForRun={numDrawsForRun}
 			/>
-			<TablesTab
+			<SummaryStatsTab
 				width={0}
 				height={0}
 			/>

--- a/src/tabs/TablesTab/SummaryStatsTab.tsx
+++ b/src/tabs/TablesTab/SummaryStatsTab.tsx
@@ -19,7 +19,7 @@ const theme = createTheme({
 	}
 });
 
-const TablesTab: FunctionComponent<Props> = ({width, height}) => {
+const SummaryStatsTab: FunctionComponent<Props> = ({width, height}) => {
 	const {selectedVariableNames, selectedChainIds} = useMCMCMonitor()
 
 	return (
@@ -46,4 +46,4 @@ const TablesTab: FunctionComponent<Props> = ({width, height}) => {
 	)
 }
 
-export default TablesTab
+export default SummaryStatsTab

--- a/src/tabs/TracePlotsTab.tsx
+++ b/src/tabs/TracePlotsTab.tsx
@@ -12,7 +12,7 @@ type TimeSeriesPlotProps = CollapsibleContentTabProps & {
     selectedVariableName: string
 }
 
-const TimeSeriesPlot: FunctionComponent<TimeSeriesPlotProps> = (props) => {
+const TracePlot: FunctionComponent<TimeSeriesPlotProps> = (props) => {
     const { runId, chainColors, numDrawsForRun, sizeScale, selectedVariableName, width } = props
     const { selectedChainIds, effectiveInitialDrawsToExclude } = useMCMCMonitor()
     const samplesRange = useSequenceDrawRange(numDrawsForRun, effectiveInitialDrawsToExclude)
@@ -32,7 +32,7 @@ const TimeSeriesPlot: FunctionComponent<TimeSeriesPlotProps> = (props) => {
     )
 }
 
-const TimeSeries: FunctionComponent<CollapsibleContentTabProps> = (props) => {
+const TracePlotsTab: FunctionComponent<CollapsibleContentTabProps> = (props) => {
     const { width, height } = props
     const {selectedVariableNames } = useMCMCMonitor()
     const [collapsedVariables, collapsedVariablesDispatch] = useReducer(collapsedVariablesReducer, {})
@@ -47,7 +47,7 @@ const TimeSeries: FunctionComponent<CollapsibleContentTabProps> = (props) => {
                 isCollapsed={collapsedVariables[v]}
                 collapsedDispatch={collapsedVariablesDispatch}
             >
-                <TimeSeriesPlot
+                <TracePlot
                     {...props}
                     selectedVariableName={v}
                     sizeScale={sizeScale}
@@ -67,4 +67,4 @@ const TimeSeries: FunctionComponent<CollapsibleContentTabProps> = (props) => {
     )
 }
 
-export default TimeSeries
+export default TracePlotsTab

--- a/src/tabs/index.ts
+++ b/src/tabs/index.ts
@@ -1,10 +1,10 @@
 export { default as AutoCorrelationTab } from './AutoCorrelationTab'
 export { default as ConnectionTab } from './ConnectionTab'
-export { default as TimeSeries } from './DiagnosticsTab'
 export { default as ExportTab } from './ExportTab'
 export { default as HistogramTab } from './HistogramTab'
 export { default as RunInfoTab } from './RunInfoTab'
 export { default as ScatterplotsTab } from './ScatterplotsTab'
 export { default as TabWidget } from './TabWidget/TabWidget'
-export { default as TablesTab } from './TablesTab/TablesTab'
+export { default as SummaryStatsTab } from './TablesTab/SummaryStatsTab'
+export { default as TracePlotsTab } from './TracePlotsTab'
 


### PR DESCRIPTION
Fix #87.

PR renames some tabular components and their descriptions in the tab metadata on `RunPage.tsx`.

Confirmed that the affected tabs still display as before.